### PR TITLE
Check name before passing to Filesystem

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -135,7 +135,7 @@ function handleRequest(request, response) {
 				"Content-Type": "application/json",
 				"Content-Disposition": 'attachment; filename="' + boardName + '.wbo"'
 			};
-		if (parts[2]) {
+		if (parts.length > 2 && !isNaN( Date.parse( parts[2] ) ) ) {
 			history_file += '.' + parts[2] + '.bak';
 		}
 		log("Downloading " + history_file);


### PR DESCRIPTION
I think it could be dangerous to pass url parts directly to the filesystem. Therefore i suggest to add some type of check. (e.g. make sure it is a valid ISO timestamp, as used in backup file names.)