### PR TITLE
Do not install on run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ EXPOSE 80
 
 VOLUME /opt/app/server-data
 
-CMD ["/usr/local/bin/node", "/opt/app/server/server.js"]
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
 FROM node:10-alpine
 
-WORKDIR /opt/app
 COPY . /opt/app
+WORKDIR /opt/app
+RUN npm install --production
 
 ENV PORT=80
 EXPOSE 80
 
 VOLUME /opt/app/server-data
 
-RUN touch /usr/bin/start.sh # this is the script which will run on start
-
-RUN echo 'npm install --production' >> /usr/bin/start.sh
-RUN echo 'node /opt/app/server/server.js' >> /usr/bin/start.sh
-
-CMD ["/bin/sh","/usr/bin/start.sh"]
+CMD ["/usr/local/bin/node", "/opt/app/server/server.js"]


### PR DESCRIPTION
The docker image should contains already resolved dependencies.

No need for a start.sh, you could just run node directly.