### PR TITLE
Fix path used for board download

### DIFF
--- a/client-data/index.css
+++ b/client-data/index.css
@@ -45,7 +45,7 @@ main {
 }
 
 main>div {
-	margin:25px;
+	margin:15px;
 	min-width: 250px;
 	padding:35px;
 	transition:.07s;
@@ -113,4 +113,39 @@ footer{
 	position:fixed;
 	bottom: 0;
 	right: 0;
+}
+
+.lang-selector {
+	top:0;
+	right:20px;
+	position: absolute;
+	width: 50px;
+	background: white;
+	border-radius: 5px;
+	transition-duration: 1s;
+	padding: 10px;
+	padding-left: 30px;
+	max-height: 25px;
+	overflow: hidden;
+	list-style: none;
+	border: 1px solid black;
+}
+
+.lang-selector:hover {
+	max-height: 300px;
+	box-shadow: 2px 2px 10px #666;
+	border: 0;
+}
+
+.lang-selector > li {
+	height: 25px;
+	padding: 5px;
+}
+
+.lang-selector:hover > li {
+	list-style: none;
+}
+
+.lang-selector > li:hover {
+	list-style:disclosure-closed;
 }

--- a/client-data/index.html
+++ b/client-data/index.html
@@ -21,11 +21,16 @@
 
 	<header>
 		<h1>WBO</h1>
+		<ul class="lang-selector">
+			{{#languages}}
+			<li><a href="?lang={{.}}">{{.}}</a></li>
+			{{/languages}}
+		</ul>
 	</header>
 
 	<main>
 		<div id="description">
-			<h3>Welcome to <strong>WBO</strong>!</h3>
+			<h3>{{translate translations 'Collaborative whiteboard'}}</h3>
 			<p>
 				WBO is a
 				<a href="https://github.com/lovasoa/whitebophir"

--- a/server/server.js
+++ b/server/server.js
@@ -101,7 +101,7 @@ function handleRequest(request, response) {
 		}
 	} else if (parts[0] === "download") {
 		var boardName = encodeURIComponent(parts[1]),
-			history_file = "server-data/board-" + boardName + ".json";
+			history_file = path.join(__dirname, "..", "server-data/board-" + boardName + ".json");
 		if (parts.length > 2 && !isNaN(Date.parse(parts[2]))) {
 			history_file += '.' + parts[2] + '.bak';
 		}

--- a/server/templating.js
+++ b/server/templating.js
@@ -1,0 +1,71 @@
+const handlebars = require("handlebars");
+const fs = require("fs");
+const path = require("path");
+const url = require("url");
+
+/**
+ * Associations from language to translation dictionnaries
+ * @const
+ * @type {object}
+ */
+const TRANSLATIONS = JSON.parse(fs.readFileSync(path.join(__dirname, "translations.json")));
+
+handlebars.registerHelper({
+    translate: function (translations, str) {
+        return translations[str] || str;
+    },
+    json: JSON.stringify.bind(JSON)
+});
+
+function findBaseUrl(req) {
+    var proto = req.headers['X-Forwarded-Proto'] || (req.connection.encrypted ? 'https' : 'http');
+    var host = req.headers['X-Forwarded-Host'] || req.headers.host;
+    return proto + '://' + host;
+}
+
+class Template {
+    constructor(path) {
+        const contents = fs.readFileSync(path, { encoding: 'utf8' });
+        this.template = handlebars.compile(contents);
+    }
+    parameters(parsedUrl, request) {
+        const user_lang = (
+            parsedUrl.query.lang ||
+            request.headers['accept-language'] ||
+            ''
+        ).slice(0, 2);
+        const language = TRANSLATIONS.hasOwnProperty(user_lang) ? user_lang : "en";
+        const languages = Object.keys(TRANSLATIONS).concat("en");
+        const translations = TRANSLATIONS[language] || {};
+        const baseUrl = findBaseUrl(request);
+        return { baseUrl, languages, language, translations };
+    }
+    serve(request, response) {
+        const parsedUrl = url.parse(request.url, true);
+        const parameters = this.parameters(parsedUrl, request);
+        var body = this.template(parameters);
+        var headers = {
+            'Content-Length': Buffer.byteLength(body),
+            'Content-Type': 'text/html',
+            'Cache-Control': 'public, max-age=3600',
+        };
+        if (!parsedUrl.query.lang) {
+            headers["Vary"] = 'Accept-Language';
+        }
+        response.writeHead(200, headers);
+        response.end(body);
+    }
+}
+
+class BoardTemplate extends Template {
+    parameters(parsedUrl, request) {
+        const params = super.parameters(parsedUrl, request);
+        const parts = parsedUrl.pathname.split('boards/', 2);
+        const boardUriComponent = parts[1];
+        params['boardUriComponent'] = boardUriComponent;
+        params['board'] = decodeURIComponent(boardUriComponent);
+        return params;
+    }
+}
+
+module.exports = { Template, BoardTemplate };


### PR DESCRIPTION
Most places in the code reference the `server-data` directory as `__dirname/../server-data`. There is a single occurrence where it is referenced directly as `./server-data`.

This pull request harmonizes the usage, so that all references are indirect via `__dirname`.

(I noticed this when packaging WBO for NixOS. There we need to decouple the `server-data` directory from the directory where the source files are stored, as the latter directory is readonly in NixOS. In the future, this decoupling could be an option for WBO; meanwhile, a simple `sed` patch gets the job done.)