### PR TITLE
Fix various bugs with the menu

### DIFF
--- a/client-data/board.css
+++ b/client-data/board.css
@@ -179,11 +179,13 @@ input {
 	display: block;
 	margin: 0;
 	padding: 0;
+	vertical-align: top;
 }
 
 .colorPresets {
 	margin-right: 20px;
 	vertical-align: top;
+	display: inline-block;
 }
 
 .colorPresetButton {

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -54,6 +54,7 @@ html, body, svg {
 	transition-duration:1s;
 	cursor:default;
 	padding: 10px;
+	pointer-events: none;
 }
 
 #menu.closed {

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -136,7 +136,7 @@ html, body, svg {
 	margin: 2.5px;
 	font-family: mono, monospace;
 	overflow: hidden;
-	pointer-events: none;
+	  pointer-events: none;
 }
 
 #menu .tool-icon > * {
@@ -177,7 +177,6 @@ input {
 	display: block;
 	margin: 0;
 	padding: 0;
-	vertical-align: top;
 }
 
 .colorPresets {

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -136,7 +136,10 @@ html, body, svg {
 	margin: 2.5px;
 	font-family: mono, monospace;
 	overflow: hidden;
-	  pointer-events: none;
+}
+
+#menu img.tool-icon {
+	pointer-events: none;
 }
 
 #menu .tool-icon > * {

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -109,10 +109,18 @@ html, body, svg {
 	box-shadow: inset 0 0 3px #8FA2BC;
 }
 
-#menu .tool:hover,
-#menu .tool:focus-within,
-#menu  #settings .tool:hover {
-	max-width:100%;
+#menu .tool:hover {
+	max-width: 100%;
+}
+
+@media (hover: none) {
+	#menu .tool:hover {
+		max-width: 40px;
+	}
+
+	#menu .tool:focus {
+		max-width: 100%;
+	}
 }
 
 #menu .tool.curTool {

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -109,19 +109,7 @@ html, body, svg {
 	box-shadow: inset 0 0 3px #8FA2BC;
 }
 
-
-@keyframes minimize {
-	to {max-width:100%;}
-}
-#menu .tool:hover {
-	color:black;
-	animation-name: minimize;
-	animation-duration: 1.2s;
-	animation-iteration-count: 2;
-	animation-timing-function: cubic-bezier(.4,.2,.2,1);
-	animation-direction: alternate;
-}
-
+#menu .tool:hover,
 #menu .tool:focus-within,
 #menu  #settings .tool:hover {
 	max-width:100%;

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -136,6 +136,7 @@ html, body, svg {
 	margin: 2.5px;
 	font-family: mono, monospace;
 	overflow: hidden;
+	pointer-events: none;
 }
 
 #menu .tool-icon > * {

--- a/client-data/board.html
+++ b/client-data/board.html
@@ -34,27 +34,27 @@
 	<div id="menu">
 		<div id="menuItems">
 			<ul id="tools" class="tools">
-				<li class="tool">
+				<li class="tool" tabindex="-1">
 					<img class="tool-icon" width="35" height="35" src="" alt="icon" /><span class="tool-name"></span>
 				</li>
 			</ul>
 
 			<ul class="tools" id="settings">
-				<li class="tool">
+				<li class="tool" tabindex="-1">
 					<input class="tool-icon" type="color" id="chooseColor" value="#1913B0" />
 					<label class="tool-name" for="chooseColor">{{translations.color}}</label>
 					<span class="colorPresets" id="colorPresetSel">
 						<span class="colorPresetButton"></span>
 					</span>
 				</li>
-				<li class="tool">
+				<li class="tool" tabindex="-1">
 					<img class="tool-icon" width="60" height="60" src="icon-size.svg" alt="size" />
 					<label class="tool-name slider" for="chooseSize">
 						<span>{{translations.size}}</span>
 						<input type="range" id="chooseSize" value="4" min="1" max="50" step="1" class="rangeChooser" />
 					</label>
 				</li>
-				<li class="tool">
+				<li class="tool" tabindex="-1">
 					<span class="tool-icon">
 						<svg viewBox="0 0 8 8">
 							<pattern id="opacityPattern" x="0" y="0" width="4" height="4" patternUnits="userSpaceOnUse">

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -426,16 +426,10 @@ Tools.toolHooks = [
 		}
 
 		function wrapUnsetHover(f, toolName) {
-			// test for mobile device
-			// https://stackoverflow.com/a/24600597
-			if (/Mobi|Android/i.test(navigator.userAgent)) {
-				return (function unsetHover(evt) {
-					document.activeElement.blur();
-					return f(evt);
-				});
-			} else {
-				return f;
-			}
+			return (function unsetHover(evt) {
+				document.activeElement && document.activeElement.blur();
+				return f(evt);
+			});
 		}
 
 		if (listeners.press) {

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -425,9 +425,22 @@ Tools.toolHooks = [
 			});
 		}
 
+		function wrapUnsetHover(f, toolName) {
+			// test for mobile device
+			// https://stackoverflow.com/a/24600597
+			if (/Mobi|Android/i.test(navigator.userAgent)) {
+				return (function unsetHover(evt) {
+					document.activeElement.blur();
+					return f(evt);
+				});
+			} else {
+				return f;
+			}
+		}
+
 		if (listeners.press) {
-			compiled["mousedown"] = compile(listeners.press);
-			compiled["touchstart"] = compileTouch(listeners.press);
+			compiled["mousedown"] = wrapUnsetHover(compile(listeners.press), tool.name);
+			compiled["touchstart"] = wrapUnsetHover(compileTouch(listeners.press), tool.name);
 		}
 		if (listeners.move) {
 			compiled["mousemove"] = compile(listeners.move);


### PR DESCRIPTION
- Fix the color picker UI issues (Fixes #48)
- Fixes the fact that currently when a tooltip is opened you cannot click into the area below or above it to close it again
- Disables the automatic closing of the tooltips
- Changes from `:hover` to `:focus` on mobile and blurs focus on tool input (basically on click into canvas)
- Close settings sliders automaticallyon desktop after making an adjustment.