### PR TITLE
Improve scroll zoom handling

### DIFF
--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -318,7 +318,7 @@ function updateDocumentTitle() {
 		clearTimeout(scrollTimeout);
 		scrollTimeout = setTimeout(function updateHistory() {
 			var hash = '#' + (x | 0) + ',' + (y | 0) + ',' + Tools.getScale().toFixed(1);
-			if (Date.now() - lastStateUpdate > 5000 && hash != window.location.hash) {
+			if (Date.now() - lastStateUpdate > 5000 && hash !== window.location.hash) {
 				window.history.pushState({}, "", hash);
 				lastStateUpdate = Date.now();
 			} else {

--- a/client-data/tools/zoom/zoom.js
+++ b/client-data/tools/zoom/zoom.js
@@ -82,11 +82,12 @@
     function onwheel(evt) {
         evt.preventDefault();
         if (evt.ctrlKey || Tools.curTool === zoomTool) {
+            console.log(evt);
             var scale = Tools.getScale();
             var x = evt.pageX / scale;
             var y = evt.pageY / scale;
             setOrigin(x, y, evt, false);
-            animate((1 - evt.deltaY * ZOOM_FACTOR / 10) * Tools.getScale());
+            animate((1 - evt.deltaY * ZOOM_FACTOR / 100) * Tools.getScale());
         } else {
             window.scrollTo(window.scrollX + evt.deltaX, window.scrollY + evt.deltaY);
         }

--- a/client-data/tools/zoom/zoom.js
+++ b/client-data/tools/zoom/zoom.js
@@ -82,12 +82,11 @@
     function onwheel(evt) {
         evt.preventDefault();
         if (evt.ctrlKey || Tools.curTool === zoomTool) {
-            console.log(evt);
             var scale = Tools.getScale();
             var x = evt.pageX / scale;
             var y = evt.pageY / scale;
             setOrigin(x, y, evt, false);
-            animate((1 - evt.deltaY * ZOOM_FACTOR / 100) * Tools.getScale());
+            animate((1 - Math.sign(evt.deltaY) * 0.25) * Tools.getScale());
         } else {
             window.scrollTo(window.scrollX + evt.deltaX, window.scrollY + evt.deltaY);
         }

--- a/client-data/tools/zoom/zoom.js
+++ b/client-data/tools/zoom/zoom.js
@@ -86,7 +86,7 @@
             var x = evt.pageX / scale;
             var y = evt.pageY / scale;
             setOrigin(x, y, evt, false);
-            animate((1 - Math.sign(evt.deltaY) * 0.25) * Tools.getScale());
+            animate((1 - ((evt.deltaY > 0) - (evt.deltaY < 0)) * 0.25) * Tools.getScale());
         } else {
             window.scrollTo(window.scrollX + evt.deltaX, window.scrollY + evt.deltaY);
         }


### PR DESCRIPTION
This fixes a bug where if you scroll-zoom out, no matter how fare zoomed in you were, the scale gets set to 0.1
Now all browsers should zoom with the same step size