### PR TITLE
Decrease area occluded by menu and fix menu scroll issue on mobile

### DIFF
--- a/client-data/board.css
+++ b/client-data/board.css
@@ -50,7 +50,7 @@ html, body, svg {
 	left:0;
 	top:0;
 	color:black;
-	height:100%;
+	max-height:100%;
 	transition-duration:1s;
 	cursor:default;
 	padding: 10px;
@@ -81,6 +81,10 @@ html, body, svg {
 #menu .tools {
 	list-style-type:none;
 	padding:0;
+}
+
+#settings {
+	margin-bottom: 0;
 }
 
 #menu .tool {

--- a/client-data/board.css
+++ b/client-data/board.css
@@ -43,16 +43,16 @@ html, body, svg {
 	-ms-overflow-style: none;
 	scrollbar-width: none;
 	font-size: 16px;
-	border-radius:0;
-	overflow-y:scroll;
-	position:fixed;
+	border-radius: 0;
+	overflow-y: scroll;
+	position: fixed;
 	margin-bottom: 30px;
-	left:0;
-	top:0;
-	color:black;
-	max-height:100%;
-	transition-duration:1s;
-	cursor:default;
+	left: 0;
+	top: 0;
+	color: black;
+	max-height: 100%;
+	transition-duration: 1s;
+	cursor: default;
 	padding: 10px;
 	pointer-events: none;
 }
@@ -125,6 +125,15 @@ html, body, svg {
 	#menu .tool:focus {
 		max-width: 100%;
 	}
+
+	#menu {
+		pointer-events: auto;
+	}
+
+	#menu:focus-within {
+		pointer-events: none;
+	}
+
 }
 
 #menu .tool.curTool {


### PR DESCRIPTION
Due to `pointer-events: none` on `#menu' it was no longer possible to scroll the menu on mobile devices where it might get cut off.
This only disables the pointer-events on desktop devices where a scrollwheel should exist to scroll the menu in the unlikely event that it overflows.

<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
