### PR TITLE
Remove extra urlencode call

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -91,7 +91,7 @@ function handleRequest(request, response) {
 			break;
 
 		case "download":
-			var boardName = encodeURIComponent(parts[1]),
+			var boardName = parts[1],
 				history_file = path.join(config.HISTORY_DIR, "board-" + boardName + ".json");
 			if (parts.length > 2 && /^[0-9A-Za-z.\-]+$/.test(parts[2])) {
 				history_file += '.' + parts[2] + '.bak';
@@ -109,7 +109,7 @@ function handleRequest(request, response) {
 			break;
 
 		case "preview":
-			var boardName = encodeURIComponent(parts[1]),
+			var boardName = parts[1],
 				history_file = path.join(config.HISTORY_DIR, "board-" + boardName + ".json");
 			createSVG.renderBoard(history_file, function (err, svg) {
 				if (err) {

--- a/server/server.js
+++ b/server/server.js
@@ -68,6 +68,11 @@ function handler(request, response) {
 const boardTemplate = new templating.BoardTemplate(path.join(config.WEBROOT, 'board.html'));
 const indexTemplate = new templating.Template(path.join(config.WEBROOT, 'index.html'));
 
+function assertEncodedBoardName(boardName) {
+	if (boardName.match(/^[\w%]*$/)) return;
+	throw new Error("Illegal characters in board name");
+}
+
 function handleRequest(request, response) {
 	var parsedUrl = url.parse(request.url, true);
 	var parts = parsedUrl.pathname.split('/');
@@ -82,6 +87,7 @@ function handleRequest(request, response) {
 				response.writeHead(301, headers);
 				response.end();
 			} else if (parts.length === 2 && request.url.indexOf('.') === -1) {
+				assertEncodedBoardName(parts[1]);
 				// If there is no dot and no directory, parts[1] is the board name
 				boardTemplate.serve(request, response);
 			} else { // Else, it's a resource
@@ -93,6 +99,7 @@ function handleRequest(request, response) {
 		case "download":
 			var boardName = parts[1],
 				history_file = path.join(config.HISTORY_DIR, "board-" + boardName + ".json");
+			assertEncodedBoardName(parts[1]);
 			if (parts.length > 2 && /^[0-9A-Za-z.\-]+$/.test(parts[2])) {
 				history_file += '.' + parts[2] + '.bak';
 			}
@@ -111,6 +118,7 @@ function handleRequest(request, response) {
 		case "preview":
 			var boardName = parts[1],
 				history_file = path.join(config.HISTORY_DIR, "board-" + boardName + ".json");
+			assertEncodedBoardName(parts[1]);
 			createSVG.renderBoard(history_file, function (err, svg) {
 				if (err) {
 					log(err);

--- a/server/server.js
+++ b/server/server.js
@@ -68,9 +68,9 @@ function handler(request, response) {
 const boardTemplate = new templating.BoardTemplate(path.join(config.WEBROOT, 'board.html'));
 const indexTemplate = new templating.Template(path.join(config.WEBROOT, 'index.html'));
 
-function assertEncodedBoardName(boardName) {
-	if (boardName.match(/^[\w%]*$/)) return;
-	throw new Error("Illegal characters in board name");
+function validateBoardName(boardName) {
+	if (/^[\w%]*$/.test(boardName)) return boardName;
+	throw new Error("Illegal board name: " + boardName);
 }
 
 function handleRequest(request, response) {
@@ -87,7 +87,7 @@ function handleRequest(request, response) {
 				response.writeHead(301, headers);
 				response.end();
 			} else if (parts.length === 2 && request.url.indexOf('.') === -1) {
-				assertEncodedBoardName(parts[1]);
+				validateBoardName(parts[1]);
 				// If there is no dot and no directory, parts[1] is the board name
 				boardTemplate.serve(request, response);
 			} else { // Else, it's a resource
@@ -97,9 +97,8 @@ function handleRequest(request, response) {
 			break;
 
 		case "download":
-			var boardName = parts[1],
+			var boardName = validateBoardName(parts[1]),
 				history_file = path.join(config.HISTORY_DIR, "board-" + boardName + ".json");
-			assertEncodedBoardName(parts[1]);
 			if (parts.length > 2 && /^[0-9A-Za-z.\-]+$/.test(parts[2])) {
 				history_file += '.' + parts[2] + '.bak';
 			}
@@ -116,9 +115,8 @@ function handleRequest(request, response) {
 			break;
 
 		case "preview":
-			var boardName = parts[1],
+			var boardName = validateBoardName(parts[1]),
 				history_file = path.join(config.HISTORY_DIR, "board-" + boardName + ".json");
-			assertEncodedBoardName(parts[1]);
 			createSVG.renderBoard(history_file, function (err, svg) {
 				if (err) {
 					log(err);


### PR DESCRIPTION
I have not been able to find an occasion where a board that has been created properly would become inaccessible with this. Neither have I found any security issues with not urlencoding the path.

If this is a concern nevertheless we could use a small function like this
```js
function encodeIfUnencoded(str) {
	const stripped = str.split("%").join("");
	if (encodeURIComponent(stripped) === stripped) return str;
	return encodeURIComponent(str);
}
```
that would check if any characters that could be urlencoded remain (except of course for the percent sign) and only urlencode the string if they do.

Fixes #69 
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
