### PR TITLE
Pass over the string only once while escaping html special chars

### DIFF
--- a/server/createSVG.js
+++ b/server/createSVG.js
@@ -3,13 +3,15 @@ const fs = require("./fs_promises.js"),
 	wboPencilPoint = require("../client-data/tools/pencil/wbo_pencil_point.js").wboPencilPoint;
 
 function htmlspecialchars(str) {
-	//Hum, hum... Could do better
 	if (typeof str !== "string") return "";
-	return str.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#039;");
+
+	return str.replace(/[<>&"']/g, function (c) {
+		switch (c) {
+			case '<': return '&lt;';
+			case '>': return '&gt;';
+			case '&': return '&amp;';
+			case '"': return '&quot;';
+			case "'": return '&#39;'; }});
 }
 
 function renderPath(el, pathstring) {


### PR DESCRIPTION
In the `server/createSVG.js` file is a comment stating `Hum, hum... Could do better` in a function that to escape five types of characters from string passes on the string five times.
As small pull request I replaced that code to do the same, but passing on the string once.

<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
