### PR TITLE
Promise.finally polyfill added

### DIFF
--- a/client-data/board.html
+++ b/client-data/board.html
@@ -85,6 +85,7 @@
 	<script type="application/json" id="translations">{{{ json translations }}}</script>
 	<script type="application/json" id="configuration">{{{ json configuration }}}</script>
 	<script src="../js/path-data-polyfill.js"></script>
+	<script src="../js/promise-finally-polyfill.js"></script>
 	<script src="../js/minitpl.js"></script>
 	<script src="../js/board.js"></script>
 	<script src="../tools/pencil/wbo_pencil_point.js"></script>

--- a/client-data/js/promise-finally-polyfill.js
+++ b/client-data/js/promise-finally-polyfill.js
@@ -1,0 +1,32 @@
+/**
+ * This polyfill resolves Promise.finally problem for old browsers. For example iOS Safari less than 11.5
+ * */
+(function () {
+
+  // Get a handle on the global object
+  let globalObject;
+  if (typeof global !== 'undefined') {
+    globalObject = global;
+  } else if (typeof window !== 'undefined' && window.document) {
+    globalObject = window;
+  }
+
+  // check if the implementation is available
+  if (typeof Promise.prototype['finally'] === 'function') {
+    return;
+  }
+
+  // implementation
+  globalObject.Promise.prototype['finally'] = function (callback) {
+    const constructor = this.constructor;
+    return this.then(function (value) {
+      return constructor.resolve(callback()).then(function () {
+        return value;
+      });
+    }, function (reason) {
+      return constructor.resolve(callback()).then(function () {
+        throw reason;
+      });
+    });
+  };
+}());


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
Hey everyone! 
I have added Promise.finally polyfill into the client-data/js. It is useful for old browsers such as Safari <= 11.3
At least it solved a trouble to me. I hope it will be useful for someone else.
Cheers!