### PR TITLE
rename MAX_CURSOR_UPDATES_INTERVAL_MS to MIN_…

### DIFF
--- a/client-data/tools/cursor/cursor.js
+++ b/client-data/tools/cursor/cursor.js
@@ -27,7 +27,7 @@
 (function () { // Code isolation
 
     // Allocate half of the maximum server updates to cursor updates
-    var MAX_CURSOR_UPDATES_INTERVAL_MS = Tools.server_config.MAX_EMIT_COUNT_PERIOD / Tools.server_config.MAX_EMIT_COUNT * 2;
+    var MIN_CURSOR_UPDATES_INTERVAL_MS = Tools.server_config.MAX_EMIT_COUNT_PERIOD / Tools.server_config.MAX_EMIT_COUNT * 2;
 
     var CURSOR_DELETE_AFTER_MS = 1000 * 5;
 
@@ -74,7 +74,7 @@
     function updateMarker() {
         if (!Tools.showMarker || !Tools.showMyCursor) return;
         var cur_time = Date.now();
-        if (cur_time - lastCursorUpdate > MAX_CURSOR_UPDATES_INTERVAL_MS &&
+        if (cur_time - lastCursorUpdate > MIN_CURSOR_UPDATES_INTERVAL_MS &&
             (sending || Tools.curTool.showMarker)) {
             Tools.drawAndSend(message, cursorTool);
             lastCursorUpdate = cur_time;


### PR DESCRIPTION
Since it is the minimum interval, not the maximum.  Just came across this in reading the code.  This doesn't address any particular issue, it's just something I came across while reading the code to address #81.  But this "bug" is itself unrelated to that issue.

<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
