### PR TITLE
make pencil more responsive, and even more so if the server throttles…

### DIFF
--- a/client-data/tools/pencil/pencil.js
+++ b/client-data/tools/pencil/pencil.js
@@ -26,6 +26,14 @@
 
 (function () { //Code isolation
 
+	// Allocate the full maximum server update rate to pencil messages.
+	// This feels a bit risky in terms of dropped messages, but any less
+	// gives terrible results with the default parameters.  In practice it
+	// seems to work, either because writing tends to happen in bursts, or
+	// maybe because the messages are sent when the time interval is *greater*
+	// than this?
+	var MIN_PENCIL_INTERVAL_MS = Tools.server_config.MAX_EMIT_COUNT_PERIOD / Tools.server_config.MAX_EMIT_COUNT;
+
 	//Indicates the id of the line the user is currently drawing or an empty string while the user is not drawing
 	var curLineId = "",
 		lastTime = performance.now(); //The time at which the last point was drawn
@@ -60,7 +68,7 @@
 	function continueLine(x, y, evt) {
 		/*Wait 70ms before adding any point to the currently drawing line.
 		This allows the animation to be smother*/
-		if (curLineId !== "" && performance.now() - lastTime > 70) {
+		if (curLineId !== "" && performance.now() - lastTime > MIN_PENCIL_INTERVAL_MS) {
 			Tools.drawAndSend(new PointMessage(x, y));
 			lastTime = performance.now();
 		}


### PR DESCRIPTION
This partially fixes #81 .  In a sense it is two changes in one (and you could pick either).  Firstly, I made the minimum time interval between stroke messages depend on `MAX_EMIT_COUNT_PERIOD` and `MAX_EMIT_COUNT` in much the same way that the cursor already does.  If I had used the same formula as the cursor (half the maximum rate), the time interval would have been identical to the previous value.  One then would have addressed #81 by changing the throttling rate.  However, I found that I could get away with devoting the full throttled bandwidth to the stroke, which gave significantly better performance on my tablet.  So I did that.  To get really nice writing, one will have to increase `MAX_EMIT_COUNT`.  It would be lovely to document that somewhere, or to just increase the default value a bit so the default is more acceptable.

<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
