### PR TITLE
environment variable WBO_MAX_BOARD_SIZE_X to give max width of board (closes #118)

### DIFF
--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -418,7 +418,7 @@ function resizeCanvas(m) {
         Tools.svg.width.baseVal.value = Math.min(x + 2000, Tools.server_config.MAX_BOARD_SIZE_X);
 	}
 	if (y > Tools.svg.height.baseVal.value - 2000) {
-        Tools.svg.height.baseVal.value = Math.min(y + 2000, Tools.server_config.MAX_BOARD_SIZE);
+		Tools.svg.height.baseVal.value = Math.min(y + 2000, Tools.server_config.MAX_BOARD_SIZE);
 	}
 }
 

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -414,12 +414,11 @@ function updateDocumentTitle() {
 function resizeCanvas(m) {
 	//Enlarge the canvas whenever something is drawn near its border
 	var x = m.x | 0, y = m.y | 0
-	var MAX_BOARD_SIZE = 65536; // Maximum value for any x or y on the board
 	if (x > Tools.svg.width.baseVal.value - 2000) {
-		Tools.svg.width.baseVal.value = Math.min(x + 2000, MAX_BOARD_SIZE);
+        Tools.svg.width.baseVal.value = Math.min(x + 2000, Tools.server_config.MAX_BOARD_SIZE_X);
 	}
 	if (y > Tools.svg.height.baseVal.value - 2000) {
-		Tools.svg.height.baseVal.value = Math.min(y + 2000, MAX_BOARD_SIZE);
+        Tools.svg.height.baseVal.value = Math.min(y + 2000, Tools.server_config.MAX_BOARD_SIZE);
 	}
 }
 
@@ -436,6 +435,7 @@ var scaleTimeout = null;
 Tools.setScale = function setScale(scale) {
 	if (isNaN(scale)) scale = 1;
 	scale = Math.max(0.1, Math.min(10, scale));
+	scale = Math.min(scale, document.documentElement.clientWidth/Tools.server_config.MAX_BOARD_SIZE_X);
 	Tools.svg.style.willChange = 'transform';
 	Tools.svg.style.transform = 'scale(' + scale + ')';
 	clearTimeout(scaleTimeout);

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -415,7 +415,7 @@ function resizeCanvas(m) {
 	//Enlarge the canvas whenever something is drawn near its border
 	var x = m.x | 0, y = m.y | 0
 	if (x > Tools.svg.width.baseVal.value - 2000) {
-        Tools.svg.width.baseVal.value = Math.min(x + 2000, Tools.server_config.MAX_BOARD_SIZE_X);
+		Tools.svg.width.baseVal.value = Math.min(x + 2000, Tools.server_config.MAX_BOARD_SIZE_X);
 	}
 	if (y > Tools.svg.height.baseVal.value - 2000) {
 		Tools.svg.height.baseVal.value = Math.min(y + 2000, Tools.server_config.MAX_BOARD_SIZE);

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -434,8 +434,8 @@ Tools.scale = 1.0;
 var scaleTimeout = null;
 Tools.setScale = function setScale(scale) {
 	if (isNaN(scale)) scale = 1;
-	scale = Math.max(0.1, Math.min(10, scale));
-	scale = Math.min(scale, document.documentElement.clientWidth/Tools.server_config.MAX_BOARD_SIZE_X);
+	var max_scale = document.documentElement.clientWidth/Tools.server_config.MAX_BOARD_SIZE_X;
+	scale = Math.max(0.1, Math.min(10, max_scale, scale));
 	Tools.svg.style.willChange = 'transform';
 	Tools.svg.style.transform = 'scale(' + scale + ')';
 	clearTimeout(scaleTimeout);

--- a/server/client_configuration.js
+++ b/server/client_configuration.js
@@ -3,6 +3,7 @@ const config = require("./configuration");
 /** Settings that should be handed through to the clients  */
 module.exports = {
     "MAX_BOARD_SIZE": config.MAX_BOARD_SIZE,
+    "MAX_BOARD_SIZE_X": config.MAX_BOARD_SIZE_X,
     "MAX_EMIT_COUNT": config.MAX_EMIT_COUNT,
     "MAX_EMIT_COUNT_PERIOD": config.MAX_EMIT_COUNT_PERIOD,
     "BLOCKED_TOOLS": config.BLOCKED_TOOLS,

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -26,6 +26,9 @@ module.exports = {
     /** Maximum value for any x or y on the board */
     MAX_BOARD_SIZE: parseInt(process.env['WBO_MAX_BOARD_SIZE']) || 65536,
 
+    /** Maximum value for any x on the board */
+    MAX_BOARD_SIZE_X: parseInt(process.env['WBO_MAX_BOARD_SIZE_X']) || parseInt(process.env['WBO_MAX_BOARD_SIZE']) || 65536,
+
     /** Maximum messages per user over the given time period before banning them  */
     MAX_EMIT_COUNT: parseInt(process.env['WBO_MAX_EMIT_COUNT']) || 192,
 


### PR DESCRIPTION
I just added a configuration variable MAX_BOARD_SIZE_X.  I also made `board.js` obey the existing `MAX_BOARD_SIZE` (which it wasn't), and made it so you can't zoom out beyond the width of the board.  The latter isn't technically necessary, and could in cases of a very wide window be annoying, but I think it's better than letting users confuse themselves with a bunch of white space that they can't write on.

<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
