### PR TITLE
Allow for listening only on 127.0.0.1 (or some other address)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Finally, you can start the server:
 PORT=5001 npm start
 ```
 
-This will run WBO directly on your machine, on port 5001, without any isolation from the other services.
+This will run WBO directly on your machine, on port 5001, without any isolation from the other services. You can also use an invokation like
+```
+PORT=5001 HOST=127.0.0.1 npm start
+```
+to make whitebophir only listen on the loopback device. This is useful if you want to put whitebophir behind a reverse proxy.
 
 ### Running WBO on a subfolder
 

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -5,6 +5,11 @@ module.exports = {
     /** Port on which the application will listen */
     PORT: parseInt(process.env['PORT']) || 8080,
 
+    /** Host on which the application will listen (defaults to undefined,
+        hence listen on all interfaces on all IP addresses, but could also be
+        '127.0.0.1' **/
+    HOST: process.env['HOST'] || undefined,
+
     /** Path to the directory where boards will be saved by default */
     HISTORY_DIR: process.env['WBO_HISTORY_DIR'] || path.join(app_root, "server-data"),
 

--- a/server/server.js
+++ b/server/server.js
@@ -22,7 +22,7 @@ if (parseFloat(process.versions.node) < MIN_NODE_VERSION) {
 
 var io = sockets.start(app);
 
-app.listen(config.PORT);
+app.listen(config.PORT, config.HOST);
 log("server started", { port: config.PORT });
 
 var CSP = "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:";


### PR DESCRIPTION
Useful for putting whitebophir behind a reverse proxy, where unrestricted access directly to whitebophir is unneeded and undesirable.

Please note that I didn't test this commit, as the machine I'm currently on isn't set up for Node development. But the change is fairly minimal.

<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
