### PR TITLE
Remember and restore white-out size

### DIFF
--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -240,6 +240,22 @@ Tools.change = function (toolName) {
 			var props = newTool.secondary.active ? newTool.secondary : newTool;
 			Tools.HTML.toggle(newTool.name, props.name, props.icon);
 			if (newTool.secondary.switch) newTool.secondary.switch();
+
+			//Toggle size
+			var oldSubTool, newSubTool;
+			if (newTool.secondary.active) {
+				oldSubTool = newTool;
+				newSubTool = newTool.secondary;
+			} else {
+				oldSubTool = newTool.secondary;
+				newSubTool = newTool;
+			}
+			if (oldSubTool.size != null) {
+				oldSubTool.size = Tools.getSize();
+			}
+			if (newSubTool.size != null && newSubTool.size != -1) {
+				Tools.setSize(newSubTool.size);
+			}
 		}
 		return;
 	}

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -240,22 +240,6 @@ Tools.change = function (toolName) {
 			var props = newTool.secondary.active ? newTool.secondary : newTool;
 			Tools.HTML.toggle(newTool.name, props.name, props.icon);
 			if (newTool.secondary.switch) newTool.secondary.switch();
-
-			//Toggle size
-			var oldSubTool, newSubTool;
-			if (newTool.secondary.active) {
-				oldSubTool = newTool;
-				newSubTool = newTool.secondary;
-			} else {
-				oldSubTool = newTool.secondary;
-				newSubTool = newTool;
-			}
-			if (oldSubTool.size != null) {
-				oldSubTool.size = Tools.getSize();
-			}
-			if (newSubTool.size != null && newSubTool.size != -1) {
-				Tools.setSize(newSubTool.size);
-			}
 		}
 		return;
 	}

--- a/client-data/tools/pencil/pencil.js
+++ b/client-data/tools/pencil/pencil.js
@@ -139,6 +139,24 @@
 		return line;
 	}
 
+	//Remember primary and secondary sizes separately
+	var pencilSize = -1;
+	var whiteOutSize = -1;
+
+	//Restore remembered size after switch
+	function toggleSize() {
+		if (pencilTool.secondary.active) {
+			pencilSize = Tools.getSize();
+			if (whiteOutSize != -1) {
+				Tools.setSize(whiteOutSize);
+			}
+		} else {
+			whiteOutSize = Tools.getSize();
+			if (pencilSize != -1) {
+				Tools.setSize(pencilSize);
+			}
+		}
+	}
 
 	var pencilTool = {
 		"name": "Pencil",
@@ -153,13 +171,20 @@
 			"name": "White-out",
 			"icon": "tools/pencil/whiteout_tape.svg",
 			"active": false,
-			"switch": stopLine,
-			"size": -1
+			"switch": function() {
+				stopLine();
+				toggleSize();
+			},
+		},
+		"onquit": function() {
+			//When switching to another tool, restore Pencil and its size
+			if (pencilTool.secondary.active) {
+				Tools.change("Pencil");
+			}
 		},
 		"mouseCursor": "url('tools/pencil/cursor.svg'), crosshair",
 		"icon": "tools/pencil/icon.svg",
 		"stylesheet": "tools/pencil/pencil.css",
-		"size": -1
 	};
 	Tools.add(pencilTool);
 

--- a/client-data/tools/pencil/pencil.js
+++ b/client-data/tools/pencil/pencil.js
@@ -139,22 +139,30 @@
 		return line;
 	}
 
-	//Remember primary and secondary sizes separately
-	var pencilSize = -1;
+	//Remember drawing and white-out sizes separately
+	var drawingSize = -1;
 	var whiteOutSize = -1;
+
+	function restoreDrawingSize() {
+		whiteOutSize = Tools.getSize();
+		if (drawingSize != -1) {
+			Tools.setSize(drawingSize);
+		}
+	}
+
+	function restoreWhiteOutSize() {
+		drawingSize = Tools.getSize();
+		if (whiteOutSize != -1) {
+			Tools.setSize(whiteOutSize);
+		}
+	}
 
 	//Restore remembered size after switch
 	function toggleSize() {
 		if (pencilTool.secondary.active) {
-			pencilSize = Tools.getSize();
-			if (whiteOutSize != -1) {
-				Tools.setSize(whiteOutSize);
-			}
+			restoreWhiteOutSize();
 		} else {
-			whiteOutSize = Tools.getSize();
-			if (pencilSize != -1) {
-				Tools.setSize(pencilSize);
-			}
+			restoreDrawingSize();
 		}
 	}
 
@@ -176,10 +184,16 @@
 				toggleSize();
 			},
 		},
-		"onquit": function() {
-			//When switching to another tool, restore Pencil and its size
+		"onstart": function() {
+			//When switching from another tool to white-out, restore white-out size
 			if (pencilTool.secondary.active) {
-				Tools.change("Pencil");
+				restoreWhiteOutSize();
+			}
+		},
+		"onquit": function() {
+			//When switching from white-out to another tool, restore drawing size
+			if (pencilTool.secondary.active) {
+				restoreDrawingSize();
 			}
 		},
 		"mouseCursor": "url('tools/pencil/cursor.svg'), crosshair",

--- a/client-data/tools/pencil/pencil.js
+++ b/client-data/tools/pencil/pencil.js
@@ -154,10 +154,12 @@
 			"icon": "tools/pencil/whiteout_tape.svg",
 			"active": false,
 			"switch": stopLine,
+			"size": -1
 		},
 		"mouseCursor": "url('tools/pencil/cursor.svg'), crosshair",
 		"icon": "tools/pencil/icon.svg",
-		"stylesheet": "tools/pencil/pencil.css"
+		"stylesheet": "tools/pencil/pencil.css",
+		"size": -1
 	};
 	Tools.add(pencilTool);
 


### PR DESCRIPTION
Remember "White-Out" and "Pencil" sizes and restore when switching between the two. This is helpful when using "White-Out" as an eraser and switching frequently, as one typically wants eraser to have larger radius.

<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
