### PR TITLE
Docker - Remove unnecessary permission change of bind-mount directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM node:14-alpine
 
-
 WORKDIR /opt/app
-
-RUN chown -R 1000:1000 /opt/app
-
-USER 1000:1000
 
 COPY package.json package-lock.json ./
 RUN npm ci --production

--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ If you have your own web server, and want to run a private instance of WBO on it
 If you use the [docker](https://www.docker.com/) containerization service, you can easily run WBO as a container. 
 An official docker image for WBO is hosted on dockerhub as [`lovasoa/wbo`](https://hub.docker.com/repository/docker/lovasoa/wbo).
 
-You can run the following bash command to launch WBO on port 5001, while persisting the boards outside of docker:
-
+You can run the following bash command to launch WBO on port 5001. This command also creates a anonymous volume to persist the board data.
 ```bash
-mkdir wbo-boards # Create a directory that will contain your whiteboards
-chown -R 1000:1000 wbo-boards # Make this directory accessible to WBO
-docker run -it --publish 5001:8080 --volume "$(pwd)/wbo-boards:/opt/app/server-data" lovasoa/wbo:latest # run wbo
+docker run -it --publish 5001:8080 lovasoa/wbo:latest # run wbo
 ```
-
+If you want to persist the board data in a named volume you have to create this volume first and bind-mount it to the corresponding directory inside the container.
+```bash
+docker volume create wbo # create volume
+docker run -it --publish 5001:8080 --volume wbo:/opt/app/server-data lovasoa/wbo:latest # run wbo
+```
+Or alternatively bind the board data to some local directory of yours.
+```bash
+mkdir /your/wbo/directory # create directory
+docker run -it --publish 5001:8080 --volume /your/wbo/directory:/opt/app/server-data lovasoa/wbo:latest # run wbo
+```
 You can then access WBO at `http://localhost:5001`.
 
 ### Running the code without a container


### PR DESCRIPTION
While using the Docker-Image I stumbled upon the required permission change to the bind-mount directory in order to persist the boards outside of docker. This is not neccessary imo. I have updated the Dockerfile and the corresponding section in the Readme. Tested on OSX 10.14.6 and Ubuntu 18.04.5.
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
