### PR TITLE
Adds support for query parameter "hideMenu"

### DIFF
--- a/client-data/board.html
+++ b/client-data/board.html
@@ -35,7 +35,7 @@
 
 	<div id="loadingMessage">{{translations.loading}}</div>
 
-	<div id="menu">
+	<div id="menu" {{#hideMenu}}style="display:none;"{{/hideMenu}}>
 		<div id="menuItems">
 			<ul id="tools" class="tools">
 				<li class="tool" tabindex="-1">

--- a/server/templating.js
+++ b/server/templating.js
@@ -68,6 +68,7 @@ class BoardTemplate extends Template {
     const boardUriComponent = parts[1];
     params["boardUriComponent"] = boardUriComponent;
     params["board"] = decodeURIComponent(boardUriComponent);
+    params["hideMenu"] = parsedUrl.search.includes("hideMenu");
     return params;
   }
 }


### PR DESCRIPTION
This adds the ability to load a board with the menu hidden; it provides a form of "read-only" mode, but the key bindings are still active.  Use with, e.g.: 
http://localhost:5001/boards/qYAZyGdym6HqjnfaGI4yNtpdx0IMHd9qp6kaJPwbJqE-?hideMenu

The alternative, proposed in #116, was to remove the menu completely, but this would require more substantial changes to board.js (which hangs on "Loading..." if the menu is removed).
Related to #150
Related to #116

<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
