### PR TITLE
Update dockerfile COPY to use node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER 1000:1000
 
 COPY package.json package-lock.json ./
 RUN npm ci --production
-COPY . .
+COPY --chown=1000:1000 . .
 
 ENV PORT=8080
 EXPOSE 8080


### PR DESCRIPTION
This change allows the files in /opt/app to be owned by the node user (UID 1000) so that the container can be used with or without needing to map a volume. Prior to this change if you tried to run the container it would crash because the node user didn't have permissions to write to the directory.

<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
