### PR TITLE
Make navigating overflowing menu more accessible

### DIFF
--- a/client-data/board.css
+++ b/client-data/board.css
@@ -54,7 +54,6 @@ html, body, svg {
 	transition-duration: 1s;
 	cursor: default;
 	padding: 10px;
-	pointer-events: none;
 }
 
 #menu.closed {
@@ -84,7 +83,7 @@ html, body, svg {
 }
 
 #settings {
-	margin-bottom: 0;
+	margin-bottom: 20px;
 }
 
 #menu .tool {

--- a/client-data/board.html
+++ b/client-data/board.html
@@ -35,7 +35,7 @@
 
 	<div id="loadingMessage">{{translations.loading}}</div>
 
-	<div id="menu" {{#hideMenu}}style="display:none;"{{/hideMenu}}>
+	<div id="menu" tabindex="0" {{#hideMenu}}style="display:none;"{{/hideMenu}}>
 		<div id="menuItems">
 			<ul id="tools" class="tools">
 				<li class="tool" tabindex="-1">

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -682,3 +682,26 @@ Tools.svg.height.baseVal.value = document.body.clientHeight;
 	  "stylesheet" : "style.css",
 }
 */
+
+
+(function () {
+    let pos = {top: 0, scroll:0};
+    let menu = document.getElementById("menu");
+    function menu_mousedown(evt) {
+	pos = {
+	    top: menu.scrollTop,
+	    scroll: evt.clientY
+	}
+	menu.addEventListener("mousemove", menu_mousemove);
+	document.addEventListener("mouseup", menu_mouseup);
+    }
+    function menu_mousemove(evt) {
+	const dy = evt.clientY - pos.scroll;
+	menu.scrollTop = pos.top - dy;
+    }
+    function menu_mouseup(evt) {
+	menu.removeEventListener("mousemove", menu_mousemove);
+	document.removeEventListener("mouseup", menu_mouseup);
+    }
+    menu.addEventListener("mousedown", menu_mousedown);
+})()


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
This PR:
-  Makes sidebar menu draggable so it can better be navigated without a mouse.
- Removes the `pointer-events: none` style from the menu element to ensure that one can drag/scroll anywhere on the menu and not only on buttons. 
- Adds a `tabindex="0"` on the menu element to enable scrolling the menu with the keyboard.

This relates to issue #163.
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
