### PR TITLE
Add support for JWT authorisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you feel like contributing to this collaborative project, you can [translate 
 
 WBO supports authentication with a JWT. This should be passed in as a query with the key `token`, eg, `http://myboard.com/boards/test?token={token}`
 
-The `AUTH_SECRET_KEY` variable in [`configuration.js`](./server/configuration.js) should filled with the secret key for the JWT.
+The `AUTH_SECRET_KEY` variable in [`configuration.js`](./server/configuration.js) should be filled with the secret key for the JWT.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can see a list of these variables in [`configuration.js`](./server/configura
 Some important environment variables are :
  - `WBO_HISTORY_DIR` : configures the directory where the boards are saved. Defaults to `./server-data/`.
  - `WBO_MAX_EMIT_COUNT` : the maximum number of messages that a client can send per unit of time. Increase this value if you want smoother drawings, at the expense of being susceptible to denial of service attacks if your server does not have enough processing power. By default, the units of this quantity are messages per 4 seconds, and the default value is `192`.
+ - `AUTH_SECRET_KEY` : If you would like to authenticate your boards using jwt, this declares the secret key.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ See instructions on our Wiki about [how to setup a reverse proxy for WBO](https:
 WBO is available in multiple languages. The translations are stored in [`server/translations.json`](./server/translations.json). 
 If you feel like contributing to this collaborative project, you can [translate WBO into your own language](https://github.com/lovasoa/whitebophir/wiki/How-to-translate-WBO-into-your-own-language).
 
+## Authentication
+
+WBO supports authentication with a JWT. This should be passed in as a query with the key `token`, eg, `http://myboard.com/boards/test?token={token}`
+
+The `AUTH_SECRET_KEY` variable in [`configuration.js`](./server/configuration.js) should filled with the secret key for the JWT.
+
 ## Configuration
 
 When you start a WBO server, it loads its configuration from several environment variables.

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -67,7 +67,7 @@ Tools.connect = function () {
 	var token = params.get("token");
 
 	this.socket = io.connect('', {
-		"query": "token=" + token,
+		...(token && {"query" : "token=" + token}),
 		"path": window.location.pathname.split("/boards/")[0] + "/socket.io",
 		"reconnection": true,
 		"reconnectionDelay": 100, //Make the xhr connections as fast as possible

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -64,15 +64,18 @@ Tools.connect = function () {
 
 	var url = new URL(window.location);
 	var params = new URLSearchParams(url.search);
-	var token = params.get("token");
 
-	this.socket = io.connect('', {
-		...(token && {"query" : "token=" + token}),
+	var socket_params = {
 		"path": window.location.pathname.split("/boards/")[0] + "/socket.io",
 		"reconnection": true,
 		"reconnectionDelay": 100, //Make the xhr connections as fast as possible
 		"timeout": 1000 * 60 * 20 // Timeout after 20 minutes
-	});
+	}
+	if(params.has("token")) {
+		socket_params.query = "token=" + params.get("token");
+	}
+
+	this.socket = io.connect('', socket_params);
 
 	//Receive draw instructions from the server
 	this.socket.on("broadcast", function (msg) {

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -62,8 +62,12 @@ Tools.connect = function () {
 		self.socket = null;
 	}
 
+	var url = new URL(window.location);
+	var params = new URLSearchParams(url.search);
+	var token = params.get("token");
 
 	this.socket = io.connect('', {
+		"query": "token=" + token,
 		"path": window.location.pathname.split("/boards/")[0] + "/socket.io",
 		"reconnection": true,
 		"reconnectionDelay": 100, //Make the xhr connections as fast as possible

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -24,7 +24,11 @@ module.exports = {
             "args": ["-headless"]
           }
         }
-
+      }
+    },
+    "jwt": {
+      "globals": {
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.5mhBHqs5_DTLdINd9p5m7ZJ6XD0Xc55kIaCRY5r6HRA"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "whitebophir",
       "version": "1.16.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
         "async-mutex": "^0.3.1",
         "handlebars": "^4.7.7",
+        "jsonwebtoken": "^8.5.1",
         "polyfill-library": "^3.107.1",
         "serve-static": "^1.14.1",
         "socket.io": "^4",
@@ -376,6 +378,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/bytes": {
       "version": "3.1.0",
@@ -833,6 +840,14 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1908,6 +1923,35 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1921,6 +1965,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -2047,6 +2110,11 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -2058,6 +2126,31 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "node_modules/lodash.keys": {
       "version": "3.1.2",
@@ -2075,6 +2168,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/log-symbols": {
       "version": "2.2.0",
@@ -4179,6 +4277,11 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -4531,6 +4634,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -5329,6 +5440,30 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5339,6 +5474,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keyv": {
@@ -5459,6 +5613,11 @@
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -5470,6 +5629,31 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -5487,6 +5671,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "accept-language-parser": "^1.5.0",
     "async-mutex": "^0.3.1",
     "handlebars": "^4.7.7",
+    "jsonwebtoken": "^8.5.1",
     "polyfill-library": "^3.107.1",
     "serve-static": "^1.14.1",
     "socket.io": "^4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "node ./server/server.js",
-    "test": "nightwatch tests"
+    "test": "nightwatch tests && nightwatch tests --env jwt"
   },
   "main": "./server/server.js",
   "repository": {

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -55,8 +55,6 @@ module.exports = {
   */
   STATSD_URL: process.env["STATSD_URL"],
 
-  /** Method to use for authorisation of users. Currently accepted values are 'jwt' or ''(none) */
-  AUTH_METHOD: (process.env["AUTH_METHOD"] || ""),
   /** Secret key for jwt */
   AUTH_SECRET_KEY: (process.env["AUTH_SECRET_KEY"] || ""),
 };

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -54,4 +54,9 @@ module.exports = {
    * example: udp://127.0.0.1
   */
   STATSD_URL: process.env["STATSD_URL"],
+
+  /** Method to use for authorisation of users. Currently accepted values are 'jwt' or ''(none) */
+  AUTH_METHOD: (process.env["AUTH_METHOD"] || ""),
+  /** Secret key for jwt */
+  AUTH_SECRET_KEY: (process.env["AUTH_SECRET_KEY"] || ""),
 };

--- a/server/server.js
+++ b/server/server.js
@@ -122,8 +122,10 @@ function handleRequest(request, response) {
 
   if (parts[0] === "") parts.shift();
 
+  var fileExt = path.extname(parsedUrl.pathname);
+  var staticResources = ['.js','.css', '.svg', '.ico', '.png', '.jpg', 'gif'];
   // If we're not being asked for a file, then we should check permissions.
-  if(parsedUrl.pathname.indexOf(".") === -1) {
+  if(!staticResources.includes(fileExt)) {
     checkUserPermission(parsedUrl);
   }
 

--- a/server/server.js
+++ b/server/server.js
@@ -104,13 +104,9 @@ function validateBoardName(boardName) {
  */
  function userHasPermission(url) {
   if(config.AUTH_SECRET_KEY != "") {
-    if(url.searchParams.get("token")) {
-      var token = url.searchParams.get("token");
-      try {
-        jsonwebtoken.verify(token, config.AUTH_SECRET_KEY);
-      } catch(error) { // Token not valid
-        throw new Error(error)
-      }
+    var token = url.searchParams.get("token");
+    if(token) {
+      jsonwebtoken.verify(token, config.AUTH_SECRET_KEY);
     } else { // Error out as no token provided
       throw new Error("No token provided");
     }

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -1,7 +1,8 @@
 var iolib = require("socket.io"),
   { log, gauge, monitorFunction } = require("./log.js"),
   BoardData = require("./boardData.js").BoardData,
-  config = require("./configuration");
+  config = require("./configuration"),
+  jsonwebtoken = require("jsonwebtoken");
 
 /** Map from name to *promises* of BoardData
   @type {{[boardName: string]: Promise<BoardData>}}
@@ -29,6 +30,20 @@ function noFail(fn) {
 
 function startIO(app) {
   io = iolib(app);
+  if (config.AUTH_SECRET_KEY) {
+    // Middleware to check for valid jwt
+    io.use(function(socket, next) {
+      if(socket.handshake.query && socket.handshake.query.token) {
+        jsonwebtoken.verify(socket.handshake.query.token, config.AUTH_SECRET_KEY, function(err, decoded) {
+          if(err) return next(new Error("Authentication error: Invalid JWT"));
+          socket.decoded = decoded;
+          next();
+        })
+      } else {
+        next(new Error("Authentication error: No jwt provided"));
+      }
+    });
+  }
   io.on("connection", noFail(handleSocketConnection));
   return io;
 }

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -36,7 +36,6 @@ function startIO(app) {
       if(socket.handshake.query && socket.handshake.query.token) {
         jsonwebtoken.verify(socket.handshake.query.token, config.AUTH_SECRET_KEY, function(err, decoded) {
           if(err) return next(new Error("Authentication error: Invalid JWT"));
-          socket.decoded = decoded;
           next();
         })
       } else {


### PR DESCRIPTION
These changes allow support for authorisation by JWT. 

By default it's turned off but can be set by using the two new config options `AUTH_METHOD` and `AUTH_SECRET_KEY`. The JWT should be added using the query parameter `token`.

It uses the [jsonwebtoken package](https://www.npmjs.com/package/jsonwebtoken). 

Also opens the door to solve future issues like https://github.com/lovasoa/whitebophir/issues/84 to set different access levels for different users as this could be declared in the jwt.

<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
