### PR TITLE
[codex] Add read-only boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ If `AUTH_SECRET_KEY` is set, opening a board requires a valid token. You can the
 
 ```json
 {
-  "roles": ["editor:board-a", "moderator:board-b", "access:board-c"]
+  "roles": ["editor:board-a", "moderator:board-b", "reader:board-c"]
 }
 ```
 
 - `editor:<boardName>` allows editing that board.
 - `moderator:<boardName>` allows moderating that board.
-- Any other `<claim>:<boardName>` value limits the token to that board without granting editor or moderator privileges.
+- `reader:<boardName>` allows opening that board without granting editor or moderator privileges.
 
 For example, `http://myboard.com/boards/mySecretBoardName?token={token}` with:
 
@@ -160,7 +160,7 @@ Read-only state is stored in the board JSON file itself under the reserved key `
 - Without JWT auth: visibility is controlled by sharing or not sharing the board URL.
 - With JWT auth: visibility is controlled by the token you issue. Add or remove board-scoped claims to decide which boards a token may open.
 - Use `editor` or `moderator` claims for users who should write.
-- Use a different board-scoped claim, such as `access:<boardName>`, for users who should only view a read-only board.
+- Use `reader:<boardName>` for users who should only view a read-only board.
 
 ### How To Change A Board Between Writable And Read-Only
 

--- a/README.md
+++ b/README.md
@@ -85,44 +85,46 @@ If you feel like contributing to this collaborative project, you can [translate 
 
 ## Authentication
 
-WBO supports authentication using [Json Web Tokens](https://jwt.io/introduction). This should be passed in as a query with the key `token`, eg, `http://myboard.com/boards/test?token={token}`
+WBO supports authentication using [Json Web Tokens](https://jwt.io/introduction). Pass the token as a `token` query parameter, for example `http://myboard.com/boards/test?token={token}`.
 
 The `AUTH_SECRET_KEY` variable in [`configuration.js`](./server/configuration.js) should be filled with the secret key for the JWT.
 
-Within the payload, you can declare the user's roles as an array.
-Currently the only accepted roles are `moderator` and `editor`.
+### Roles
 
-- `moderator` will give the user an additional tool to wipe all data from the board. To declare this role, see the example below.
-- `editor` will give the user the ability to edit the board. This is the default role for all users.
+WBO recognizes two privileged roles:
+
+- `editor`: can modify accessible boards.
+- `moderator`: can modify accessible boards and use the Clear tool.
+
+Roles are declared in the JWT payload:
 
 ```json
 {
   "iat": 1516239022,
   "exp": 1516298489,
-  "roles": ["moderator"]
+  "roles": ["editor"]
 }
 ```
 
-Moderators have access to the Clear tool, which will wipe all content from the board.
+Moderators have access to the Clear tool, which wipes all content from the board.
 
-## Board name verification in the JWT
+### Board Visibility / Access
 
-WBO supports verification of the board with a JWT.
+If `AUTH_SECRET_KEY` is not set, boards are visible to anyone who knows the URL.
 
-To check for a valid board name just add the board name to the role with a ":". With this you can set a moderator for a specific board.
+If `AUTH_SECRET_KEY` is set, opening a board requires a valid token. You can then restrict which board names a token may open by adding `:<boardName>` to a claim:
 
 ```json
 {
-  "roles": [
-    "moderator:<boardName1>",
-    "moderator:<boardName2>",
-    "editor:<boardName3>",
-    "editor:<boardName4>"
-  ]
+  "roles": ["editor:board-a", "moderator:board-b", "access:board-c"]
 }
 ```
 
-eg, `http://myboard.com/boards/mySecretBoardName?token={token}`
+- `editor:<boardName>` allows editing that board.
+- `moderator:<boardName>` allows moderating that board.
+- Any other `<claim>:<boardName>` value limits the token to that board without granting editor or moderator privileges.
+
+For example, `http://myboard.com/boards/mySecretBoardName?token={token}` with:
 
 ```json
 {
@@ -132,7 +134,40 @@ eg, `http://myboard.com/boards/mySecretBoardName?token={token}`
 }
 ```
 
-You can now be sure that only users who have the correct token have access to the board with the specific name.
+If a token contains any board-scoped claims, it can only open the boards named in those claims.
+
+### Board Editability / Read-Only
+
+Board visibility and board editability are separate.
+
+- A writable board behaves as before.
+- A read-only board can still be opened by anyone who has access to it.
+- On a read-only board, only `editor` and `moderator` claims may write.
+- On instances without JWT authentication, a read-only board blocks all writes because there is no authenticated editor or moderator identity.
+
+Read-only state is stored in the board JSON file itself under the reserved key `__wbo_meta__`:
+
+```json
+{
+  "__wbo_meta__": {
+    "readonly": true
+  }
+}
+```
+
+### How To Change Board Visibility
+
+- Without JWT auth: visibility is controlled by sharing or not sharing the board URL.
+- With JWT auth: visibility is controlled by the token you issue. Add or remove board-scoped claims to decide which boards a token may open.
+- Use `editor` or `moderator` claims for users who should write.
+- Use a different board-scoped claim, such as `access:<boardName>`, for users who should only view a read-only board.
+
+### How To Change A Board Between Writable And Read-Only
+
+1. Find the board file in `WBO_HISTORY_DIR`. The filename is `board-${encodeURIComponent(boardName)}.json`.
+2. Add or update the `__wbo_meta__.readonly` flag in that file.
+3. Reload the board after it is unloaded from memory, or restart the server, so the new state is picked up.
+4. Remove the flag or set it to `false` to make the board writable again.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ If a token contains any board-scoped claims, it can only open the boards named i
 
 Board visibility and board editability are separate.
 
-- A writable board behaves as before.
-- A read-only board can still be opened by anyone who has access to it.
+- A writable board accepts writes from users who can access it.
+- A read-only board can be opened by users who have access to it.
 - On a read-only board, only `editor` and `moderator` claims may write.
 - On instances without JWT authentication, a read-only board blocks all writes because there is no authenticated editor or moderator identity.
 
@@ -167,7 +167,7 @@ Read-only state is stored in the board JSON file itself under the reserved key `
 1. Find the board file in `WBO_HISTORY_DIR`. The filename is `board-${encodeURIComponent(boardName)}.json`.
 2. Add or update the `__wbo_meta__.readonly` flag in that file.
 3. Reload the board after it is unloaded from memory, or restart the server, so the new state is picked up.
-4. Remove the flag or set it to `false` to make the board writable again.
+4. Remove the flag or set it to `false` to make the board writable.
 
 ## Configuration
 

--- a/client-data/board.html
+++ b/client-data/board.html
@@ -86,6 +86,7 @@
 
 	<script type="application/json" id="translations">{{{ json translations }}}</script>
 	<script type="application/json" id="configuration">{{{ json configuration }}}</script>
+	<script type="application/json" id="board-state">{{{ json boardState }}}</script>
 	<script src="../js/path-data-polyfill.js"></script>
 	<script src="../js/minitpl.js"></script>
 	<script src="../js/intersect.js"></script>

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -37,6 +37,49 @@ Tools.i18n = (function i18n() {
 })();
 
 Tools.server_config = JSON.parse(document.getElementById("configuration").text);
+Tools.readOnlyToolNames = new Set(["Hand", "Grid", "Download", "Zoom"]);
+
+Tools.setBoardState = function setBoardState(state) {
+  state = state || {};
+  Tools.boardState = {
+    readonly: state.readonly === true,
+    canWrite: state.canWrite === true,
+  };
+  Tools.readOnly = Tools.boardState.readonly;
+  Tools.canWrite = Tools.boardState.canWrite;
+
+  var hideEditingTools = Tools.readOnly && !Tools.canWrite;
+  var settings = document.getElementById("settings");
+  if (settings) settings.style.display = hideEditingTools ? "none" : "";
+
+  Object.keys(Tools.list || {}).forEach(function (toolName) {
+    var toolElem = document.getElementById("toolID-" + toolName);
+    if (!toolElem) return;
+    toolElem.style.display = Tools.shouldDisplayTool(toolName) ? "" : "none";
+  });
+
+  if (
+    hideEditingTools &&
+    Tools.curTool &&
+    !Tools.shouldDisplayTool(Tools.curTool.name) &&
+    Tools.list.Hand
+  ) {
+    Tools.change("Hand");
+  }
+};
+
+Tools.shouldDisplayTool = function shouldDisplayTool(toolName) {
+  return (
+    !Tools.readOnly || Tools.canWrite || Tools.readOnlyToolNames.has(toolName)
+  );
+};
+
+Tools.setBoardState(
+  JSON.parse(
+    document.getElementById("board-state").text ||
+      '{"readonly":false,"canWrite":true}',
+  ),
+);
 
 Tools.board = document.getElementById("board");
 Tools.svg = document.getElementById("canvas");
@@ -84,6 +127,7 @@ Tools.connect = function () {
       loadingEl.classList.add("hidden");
     });
   });
+  this.socket.on("boardstate", Tools.setBoardState);
 
   this.socket.on("reconnect", function onReconnection() {
     Tools.socket.emit("joinboard", Tools.boardName);
@@ -275,13 +319,15 @@ Tools.add = function (newTool) {
   }
 
   //Add the tool to the GUI
-  Tools.HTML.addTool(
-    newTool.name,
-    newTool.icon,
-    newTool.iconHTML,
-    newTool.shortcut,
-    newTool.oneTouch,
-  );
+  if (Tools.shouldDisplayTool(newTool.name)) {
+    Tools.HTML.addTool(
+      newTool.name,
+      newTool.icon,
+      newTool.iconHTML,
+      newTool.shortcut,
+      newTool.oneTouch,
+    );
+  }
 };
 
 Tools.change = function (toolName) {

--- a/client-data/tools/hand/hand.js
+++ b/client-data/tools/hand/hand.js
@@ -563,12 +563,14 @@
       release: release,
     },
     onquit: onquit,
-    secondary: {
-      name: "Selector",
-      icon: "tools/hand/selector.svg",
-      active: false,
-      switch: switchTool,
-    },
+    secondary: Tools.canWrite
+      ? {
+          name: "Selector",
+          icon: "tools/hand/selector.svg",
+          active: false,
+          switch: switchTool,
+        }
+      : null,
     draw: draw,
     icon: "tools/hand/hand.svg",
     mouseCursor: "move",

--- a/server/boardData.js
+++ b/server/boardData.js
@@ -26,11 +26,63 @@
  */
 
 var fs = require("./fs_promises.js"),
+  nativeFs = require("fs"),
   log = require("./log.js").log,
   path = require("path"),
   config = require("./configuration.js"),
-  Mutex = require("async-mutex").Mutex,
-  jwtauth = require("./jwtBoardnameAuth.js");
+  Mutex = require("async-mutex").Mutex;
+
+const BOARD_METADATA_KEY = "__wbo_meta__";
+
+function defaultBoardMetadata() {
+  return {
+    readonly: false,
+  };
+}
+
+function normalizeBoardMetadata(metadata) {
+  return {
+    readonly: metadata && metadata.readonly === true,
+  };
+}
+
+function boardFilePath(name) {
+  return path.join(
+    config.HISTORY_DIR,
+    "board-" + encodeURIComponent(name) + ".json",
+  );
+}
+
+function parseStoredBoard(storedBoard) {
+  if (
+    !storedBoard ||
+    typeof storedBoard !== "object" ||
+    Array.isArray(storedBoard)
+  ) {
+    throw new Error("Invalid board file format");
+  }
+
+  var board = {};
+  var metadata = defaultBoardMetadata();
+
+  for (const [key, value] of Object.entries(storedBoard)) {
+    if (key === BOARD_METADATA_KEY) {
+      metadata = normalizeBoardMetadata(value);
+    } else {
+      board[key] = value;
+    }
+  }
+
+  return { board, metadata };
+}
+
+function serializeStoredBoard(board, metadata) {
+  var storedBoard = Object.assign({}, board);
+  if (metadata && metadata.readonly) {
+    storedBoard[BOARD_METADATA_KEY] = { readonly: true };
+  }
+  return storedBoard;
+}
 
 /**
  * Represents a board.
@@ -44,13 +96,15 @@ class BoardData {
     this.name = name;
     /** @type {{[name: string]: BoardElem}} */
     this.board = {};
-    this.file = path.join(
-      config.HISTORY_DIR,
-      "board-" + encodeURIComponent(name) + ".json",
-    );
+    this.metadata = defaultBoardMetadata();
+    this.file = boardFilePath(name);
     this.lastSaveDate = Date.now();
     this.users = new Set();
     this.saveMutex = new Mutex();
+  }
+
+  isReadOnly() {
+    return this.metadata.readonly === true;
   }
 
   /** Adds data to the board
@@ -179,11 +233,7 @@ class BoardData {
         this.addChild(parent, childData);
         break;
       case "clear":
-        if (jwtauth.roleInBoard(message.token, message.board) === "moderator") {
-          this.clear();
-        } else {
-          console.error("User is not a moderator and tried to clear the board");
-        }
+        this.clear();
         break;
       default:
         //Add data
@@ -230,7 +280,8 @@ class BoardData {
     this.clean();
     var file = this.file;
     var tmp_file = backupFileName(file);
-    var board_txt = JSON.stringify(this.board);
+    var storedBoard = serializeStoredBoard(this.board, this.metadata);
+    var board_txt = JSON.stringify(storedBoard);
     if (board_txt === "{}") {
       // empty board
       try {
@@ -315,7 +366,9 @@ class BoardData {
       data;
     try {
       data = await fs.promises.readFile(boardData.file);
-      boardData.board = JSON.parse(data);
+      const storedBoard = parseStoredBoard(JSON.parse(data));
+      boardData.board = storedBoard.board;
+      boardData.metadata = storedBoard.metadata;
       for (const id in boardData.board) boardData.validate(boardData.board[id]);
       log("disk load", { board: boardData.name });
     } catch (e) {
@@ -343,6 +396,24 @@ class BoardData {
     }
     return boardData;
   }
+
+  static loadMetadataSync(name) {
+    const metadata = defaultBoardMetadata();
+    try {
+      const data = nativeFs.readFileSync(boardFilePath(name), {
+        encoding: "utf8",
+      });
+      return parseStoredBoard(JSON.parse(data)).metadata;
+    } catch (err) {
+      if (err.code !== "ENOENT") {
+        log("board metadata load error", {
+          board: name,
+          error: err.toString(),
+        });
+      }
+      return metadata;
+    }
+  }
 }
 
 /**
@@ -354,4 +425,8 @@ function backupFileName(baseName) {
   return baseName + "." + date + ".bak";
 }
 
-module.exports.BoardData = BoardData;
+module.exports = {
+  BoardData,
+  BOARD_METADATA_KEY,
+  parseStoredBoard,
+};

--- a/server/createSVG.js
+++ b/server/createSVG.js
@@ -1,5 +1,6 @@
 const fs = require("./fs_promises.js"),
   path = require("path"),
+  parseStoredBoard = require("./boardData.js").parseStoredBoard,
   wboPencilPoint =
     require("../client-data/tools/pencil/wbo_pencil_point.js").wboPencilPoint;
 
@@ -209,7 +210,7 @@ async function toSVG(obj, writeable) {
 
 async function renderBoard(file, stream) {
   const data = await fs.promises.readFile(file);
-  var board = JSON.parse(data);
+  var board = parseStoredBoard(JSON.parse(data)).board;
   return toSVG(board, stream);
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ var app = require("http").createServer(handler),
   createSVG = require("./createSVG.js"),
   templating = require("./templating.js"),
   config = require("./configuration.js"),
+  BoardData = require("./boardData.js").BoardData,
   polyfillLibrary = require("polyfill-library"),
   check_output_directory = require("./check_output_directory.js"),
   jwtauth = require("./jwtauth.js");
@@ -128,7 +129,19 @@ function handleRequest(request, response) {
       } else if (parts.length === 2 && parsedUrl.pathname.indexOf(".") === -1) {
         var boardName = validateBoardName(parts[1]);
         jwtBoardName.checkBoardnameInToken(parsedUrl, boardName);
-        boardTemplate.serve(request, response, isModerator);
+        var token = parsedUrl.searchParams.get("token");
+        var boardRole = jwtBoardName.roleInBoard(token, boardName);
+        var boardMetadata = BoardData.loadMetadataSync(boardName);
+        var canWrite =
+          !boardMetadata.readonly ||
+          (config.AUTH_SECRET_KEY &&
+            ["editor", "moderator"].includes(boardRole));
+        boardTemplate.serve(request, response, boardRole === "moderator", {
+          boardState: {
+            readonly: boardMetadata.readonly,
+            canWrite: canWrite,
+          },
+        });
         // If there is no dot and no directory, parts[1] is the board name
       } else {
         request.url = "/" + parts.slice(1).join("/");

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -2,7 +2,8 @@ var iolib = require("socket.io"),
   { log, gauge, monitorFunction } = require("./log.js"),
   BoardData = require("./boardData.js").BoardData,
   config = require("./configuration"),
-  jsonwebtoken = require("jsonwebtoken");
+  jsonwebtoken = require("jsonwebtoken"),
+  roleInBoard = require("./jwtBoardnameAuth.js").roleInBoard;
 
 /** Map from name to *promises* of BoardData
   @type {{[boardName: string]: Promise<BoardData>}}
@@ -19,13 +20,43 @@ var boards = {};
  */
 function noFail(fn) {
   const monitored = monitorFunction(fn);
-  return function noFailWrapped(arg) {
+  return function noFailWrapped() {
     try {
-      return monitored(arg);
+      const result = monitored.apply(this, arguments);
+      if (result && typeof result.catch === "function") {
+        return result.catch(function logError(err) {
+          console.trace(err);
+        });
+      }
+      return result;
     } catch (e) {
       console.trace(e);
     }
   };
+}
+
+function getSocketToken(socket) {
+  return socket.handshake.query && socket.handshake.query.token;
+}
+
+function accessRole(boardName, socket) {
+  if (!config.AUTH_SECRET_KEY) return "editor";
+  return roleInBoard(getSocketToken(socket), boardName);
+}
+
+function canAccessBoard(boardName, socket) {
+  return accessRole(boardName, socket) !== "forbidden";
+}
+
+function writerRole(boardName, socket) {
+  if (!config.AUTH_SECRET_KEY) return "forbidden";
+  const role = accessRole(boardName, socket);
+  return role === "editor" || role === "moderator" ? role : "forbidden";
+}
+
+function canWriteToBoard(board, socket) {
+  if (!board.isReadOnly()) return true;
+  return writerRole(board.name, socket) !== "forbidden";
 }
 
 function startIO(app) {
@@ -78,6 +109,9 @@ function handleSocketConnection(socket) {
   async function joinBoard(name) {
     // Default to the public board
     if (!name) name = "anonymous";
+    if (!canAccessBoard(name, socket)) {
+      throw new Error("Access forbidden");
+    }
 
     // Join the board
     socket.join(name);
@@ -96,11 +130,18 @@ function handleSocketConnection(socket) {
     }),
   );
 
-  socket.on("getboard", async function onGetBoard(name) {
-    var board = await joinBoard(name);
-    //Send all the board's data as soon as it's loaded
-    socket.emit("broadcast", { _children: board.getAll() });
-  });
+  socket.on(
+    "getboard",
+    noFail(async function onGetBoard(name) {
+      var board = await joinBoard(name);
+      socket.emit("boardstate", {
+        readonly: board.isReadOnly(),
+        canWrite: canWriteToBoard(board, socket),
+      });
+      //Send all the board's data as soon as it's loaded
+      socket.emit("broadcast", { _children: board.getAll() });
+    }),
+  );
 
   socket.on("joinboard", noFail(joinBoard));
 
@@ -108,7 +149,7 @@ function handleSocketConnection(socket) {
   var emitCount = 0;
   socket.on(
     "broadcast",
-    noFail(function onBroadcast(message) {
+    noFail(async function onBroadcast(message) {
       var currentSecond = (Date.now() / config.MAX_EMIT_COUNT_PERIOD) | 0;
       if (currentSecond === lastEmitSecond) {
         emitCount++;
@@ -133,6 +174,10 @@ function handleSocketConnection(socket) {
       var boardName = message.board || "anonymous";
       var data = message.data;
 
+      if (!canAccessBoard(boardName, socket)) {
+        log("ACCESS BLOCKED", { board: boardName });
+        return;
+      }
       if (!socket.rooms.has(boardName)) socket.join(boardName);
 
       if (!data) {
@@ -148,8 +193,27 @@ function handleSocketConnection(socket) {
         return;
       }
 
+      var board = await getBoard(boardName);
+      if (
+        data.tool !== "Cursor" &&
+        (!canWriteToBoard(board, socket) ||
+          (data.type === "clear" &&
+            writerRole(board.name, socket) !== "moderator"))
+      ) {
+        log("WRITE BLOCKED", {
+          board: board.name,
+          tool: data.tool,
+          type: data.type,
+        });
+        return;
+      }
+
       // Save the message in the board
-      handleMessage(boardName, data, socket);
+      handleMessage(
+        board,
+        data.tool === "Cursor" ? data : JSON.parse(JSON.stringify(data)),
+        socket,
+      );
 
       //Send data to all other users connected on the same board
       socket.broadcast.to(boardName).emit("broadcast", data);
@@ -188,19 +252,18 @@ async function unloadBoard(boardName) {
   }
 }
 
-function handleMessage(boardName, message, socket) {
+function handleMessage(board, message, socket) {
   if (message.tool === "Cursor") {
     message.socket = socket.id;
   } else {
-    saveHistory(boardName, message);
+    saveHistory(board, message);
   }
 }
 
-async function saveHistory(boardName, message) {
+function saveHistory(board, message) {
   if (!(message.tool || message.type === "child") && !message._children) {
     console.error("Received a badly formatted message (no tool). ", message);
   }
-  var board = await getBoard(boardName);
   board.processMessage(message);
 }
 

--- a/server/templating.js
+++ b/server/templating.js
@@ -32,7 +32,7 @@ class Template {
     const contents = fs.readFileSync(path, { encoding: "utf8" });
     this.template = handlebars.compile(contents);
   }
-  parameters(parsedUrl, request, isModerator) {
+  parameters(parsedUrl, request, isModerator, extraParams) {
     const accept_language_str =
       parsedUrl.query.lang || request.headers["accept-language"];
     const accept_languages = accept_language_parser.parse(accept_language_str);
@@ -53,18 +53,26 @@ class Template {
     const prefix = request.url.split("/boards/")[0].substr(1);
     const baseUrl = findBaseUrl(request) + (prefix ? prefix + "/" : "");
     const moderator = isModerator;
-    return {
-      baseUrl,
-      languages,
-      language,
-      translations,
-      configuration,
-      moderator,
-    };
+    return Object.assign(
+      {
+        baseUrl,
+        languages,
+        language,
+        translations,
+        configuration,
+        moderator,
+      },
+      extraParams,
+    );
   }
-  serve(request, response, isModerator) {
+  serve(request, response, isModerator, extraParams) {
     const parsedUrl = url.parse(request.url, true);
-    const parameters = this.parameters(parsedUrl, request, isModerator);
+    const parameters = this.parameters(
+      parsedUrl,
+      request,
+      isModerator,
+      extraParams,
+    );
     var body = this.template(parameters);
     var headers = {
       "Content-Length": Buffer.byteLength(body),
@@ -80,8 +88,13 @@ class Template {
 }
 
 class BoardTemplate extends Template {
-  parameters(parsedUrl, request, isModerator) {
-    const params = super.parameters(parsedUrl, request, isModerator);
+  parameters(parsedUrl, request, isModerator, extraParams) {
+    const params = super.parameters(
+      parsedUrl,
+      request,
+      isModerator,
+      extraParams,
+    );
     const parts = parsedUrl.pathname.split("boards/", 2);
     const boardUriComponent = parts[1];
     params["boardUriComponent"] = boardUriComponent;

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -25,7 +25,7 @@ const TOKENS = {
     AUTH_SECRET,
   ),
   readOnlyViewer: jsonwebtoken.sign(
-    { sub: "viewer", roles: ["access:readonly-test"] },
+    { sub: "viewer", roles: ["reader:readonly-test"] },
     AUTH_SECRET,
   ),
   readOnlyGlobalEditor: jsonwebtoken.sign(

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,11 +1,62 @@
 const fs = require("../server/fs_promises.js");
+const jsonwebtoken = require("jsonwebtoken");
 const os = require("os");
 const path = require("path");
 
 const PORT = 8487;
 const SERVER = "http://localhost:" + PORT;
+const AUTH_SECRET = "test";
+
+const TOKENS = {
+  globalModerator: jsonwebtoken.sign(
+    { sub: "moderator", roles: ["moderator"] },
+    AUTH_SECRET,
+  ),
+  boardModeratorTestboard: jsonwebtoken.sign(
+    { sub: "moderator-board", roles: ["moderator:testboard"] },
+    AUTH_SECRET,
+  ),
+  globalEditor: jsonwebtoken.sign(
+    { sub: "editor", roles: ["editor"] },
+    AUTH_SECRET,
+  ),
+  boardEditorTestboard: jsonwebtoken.sign(
+    { sub: "editor-board", roles: ["editor:testboard"] },
+    AUTH_SECRET,
+  ),
+  readOnlyViewer: jsonwebtoken.sign(
+    { sub: "viewer", roles: ["access:readonly-test"] },
+    AUTH_SECRET,
+  ),
+  readOnlyGlobalEditor: jsonwebtoken.sign(
+    { sub: "readonly-editor", roles: ["editor"] },
+    AUTH_SECRET,
+  ),
+  readOnlyBoardEditor: jsonwebtoken.sign(
+    { sub: "readonly-board-editor", roles: ["editor:readonly-test"] },
+    AUTH_SECRET,
+  ),
+  readOnlyGlobalModerator: jsonwebtoken.sign(
+    { sub: "readonly-moderator", roles: ["moderator"] },
+    AUTH_SECRET,
+  ),
+};
 
 let wbo, data_path, tokenQuery;
+
+function withToken(url, token) {
+  const query = token ? "token=" + token : tokenQuery;
+  if (!query) return url;
+  return url + (url.includes("?") ? "&" : "?") + query;
+}
+
+function boardFile(name) {
+  return path.join(data_path, "board-" + encodeURIComponent(name) + ".json");
+}
+
+async function writeBoard(name, storedBoard) {
+  await fs.promises.writeFile(boardFile(name), JSON.stringify(storedBoard));
+}
 
 async function beforeEach(browser, done) {
   data_path = await fs.promises.mkdtemp(
@@ -13,9 +64,12 @@ async function beforeEach(browser, done) {
   );
   process.env["PORT"] = PORT;
   process.env["WBO_HISTORY_DIR"] = data_path;
+  tokenQuery = "";
   if (browser.globals.token) {
-    process.env["AUTH_SECRET_KEY"] = "test";
+    process.env["AUTH_SECRET_KEY"] = AUTH_SECRET;
     tokenQuery = "token=" + browser.globals.token;
+  } else {
+    delete process.env["AUTH_SECRET_KEY"];
   }
   console.log("Launching WBO in " + data_path);
   wbo = require("../server/server.js");
@@ -152,6 +206,137 @@ function testCollaborativeness(browser) {
     });
 }
 
+function testReadOnlyBoardWithoutAuth(browser) {
+  const selector =
+    "rect[x='10'][y='10'][width='20'][height='20'][stroke='#123456']";
+
+  return browser
+    .perform(async function (done) {
+      await writeBoard("readonly-public", {
+        __wbo_meta__: { readonly: true },
+      });
+      done();
+    })
+    .url(SERVER + "/boards/readonly-public")
+    .waitForElementVisible("#toolID-Hand")
+    .assert.elementNotPresent("#toolID-Pencil")
+    .assert.elementNotPresent("#toolID-Line")
+    .waitForElementNotVisible("#settings")
+    .execute(function () {
+      Tools.socket.emit("broadcast", {
+        board: Tools.boardName,
+        data: {
+          type: "rect",
+          id: "readonly-public-rect",
+          tool: "Rectangle",
+          x: 10,
+          y: 10,
+          x2: 30,
+          y2: 30,
+          color: "#123456",
+          size: 4,
+        },
+      });
+    })
+    .refresh()
+    .waitForElementVisible("#toolID-Hand")
+    .assert.elementNotPresent(selector);
+}
+
+function testReadOnlyBoardWithJwt(browser) {
+  const selector =
+    "rect[x='10'][y='10'][width='20'][height='20'][stroke='#123456']";
+
+  return browser
+    .perform(async function (done) {
+      await writeBoard("readonly-test", {
+        __wbo_meta__: { readonly: true },
+      });
+      await writeBoard("readonly-clear", {
+        __wbo_meta__: { readonly: true },
+        "readonly-clear-rect": {
+          type: "rect",
+          id: "readonly-clear-rect",
+          tool: "Rectangle",
+          x: 10,
+          y: 10,
+          x2: 30,
+          y2: 30,
+          color: "#ff00ff",
+          size: 4,
+        },
+      });
+      done();
+    })
+    .url(withToken(SERVER + "/boards/readonly-test", TOKENS.readOnlyViewer))
+    .waitForElementVisible("#toolID-Hand")
+    .assert.elementNotPresent("#toolID-Pencil")
+    .waitForElementNotVisible("#settings")
+    .execute(function () {
+      Tools.socket.emit("broadcast", {
+        board: Tools.boardName,
+        data: {
+          type: "rect",
+          id: "readonly-viewer-rect",
+          tool: "Rectangle",
+          x: 10,
+          y: 10,
+          x2: 30,
+          y2: 30,
+          color: "#123456",
+          size: 4,
+        },
+      });
+    })
+    .refresh()
+    .waitForElementVisible("#toolID-Hand")
+    .assert.elementNotPresent(selector)
+    .url(
+      withToken(SERVER + "/boards/readonly-test", TOKENS.readOnlyGlobalEditor),
+    )
+    .waitForElementVisible("#toolID-Pencil")
+    .assert.visible("#settings")
+    .execute(function () {
+      Tools.socket.emit("broadcast", {
+        board: Tools.boardName,
+        data: {
+          type: "rect",
+          id: "readonly-editor-rect",
+          tool: "Rectangle",
+          x: 10,
+          y: 10,
+          x2: 30,
+          y2: 30,
+          color: "#123456",
+          size: 4,
+        },
+      });
+    })
+    .refresh()
+    .waitForElementVisible(selector)
+    .url(
+      withToken(SERVER + "/boards/readonly-test", TOKENS.readOnlyBoardEditor),
+    )
+    .waitForElementVisible(selector)
+    .assert.visible("#toolID-Pencil")
+    .url(
+      withToken(
+        SERVER + "/boards/readonly-clear",
+        TOKENS.readOnlyGlobalModerator,
+      ),
+    )
+    .waitForElementVisible("#toolID-Clear")
+    .waitForElementVisible(
+      "rect[x='10'][y='10'][width='20'][height='20'][stroke='#ff00ff']",
+    )
+    .click("#toolID-Clear")
+    .refresh()
+    .waitForElementVisible("#toolID-Clear")
+    .assert.elementNotPresent(
+      "rect[x='10'][y='10'][width='20'][height='20'][stroke='#ff00ff']",
+    );
+}
+
 function testBoard(browser) {
   var page = browser
     .url(SERVER + "/boards/anonymous?lang=fr&" + tokenQuery)
@@ -168,81 +353,77 @@ function testBoard(browser) {
   browser
     .url(SERVER + "/boards/anonymous?lang=fr&hideMenu=false&" + tokenQuery)
     .waitForElementVisible("#menu");
+  if (!browser.globals.token) {
+    testReadOnlyBoardWithoutAuth(browser);
+  }
   if (browser.globals.token) {
     //has moderator jwt and no board name
     browser
-      .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJtb2RlcmF0b3IiXX0.PqYHmV0loeKwyLLYZ1a1eIXBCCaa3t5lYUTu_P_-i14",
-      )
+      .url(withToken(SERVER + "/boards/testboard", TOKENS.globalModerator))
       .waitForElementVisible("#toolID-Clear");
     //has moderator JWT and other board name
     browser
-      .url(
-        SERVER +
-          "/boards/testboard123?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJtb2RlcmF0b3IiXX0.PqYHmV0loeKwyLLYZ1a1eIXBCCaa3t5lYUTu_P_-i14",
-      )
+      .url(withToken(SERVER + "/boards/testboard123", TOKENS.globalModerator))
       .waitForElementVisible("#toolID-Clear");
     //has moderator JWT and board name match board name in url
     browser
       .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJtb2RlcmF0b3I6dGVzdGJvYXJkIl19.UVf6awGEChVxcWBbt6dYoNH0Scq7cVD_xfQn-U8A1lw",
+        withToken(SERVER + "/boards/testboard", TOKENS.boardModeratorTestboard),
       )
       .waitForElementVisible("#toolID-Clear");
     //has moderator JWT and board name NOT match board name in url
     browser
       .url(
-        SERVER +
-          "/boards/testboard123?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJtb2RlcmF0b3I6dGVzdGJvYXJkIl19.UVf6awGEChVxcWBbt6dYoNH0Scq7cVD_xfQn-U8A1lw",
+        withToken(
+          SERVER + "/boards/testboard123",
+          TOKENS.boardModeratorTestboard,
+        ),
       )
       .waitForElementNotPresent("#menu");
     //has editor JWT and no boardname provided
     browser
-      .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJlZGl0b3IiXX0.IJehwM8tPVQFzJ2fZMBHveii1DRChVtzo7PEnSmmFt8",
-      )
+      .url(withToken(SERVER + "/boards/testboard", TOKENS.globalEditor))
       .waitForElementNotPresent("#toolID-Clear");
     browser
-      .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJlZGl0b3IiXX0.IJehwM8tPVQFzJ2fZMBHveii1DRChVtzo7PEnSmmFt8",
-      )
+      .url(withToken(SERVER + "/boards/testboard", TOKENS.globalEditor))
       .waitForElementVisible("#menu");
     //has editor JWT and  boardname provided and match to the board in the url
     browser
-      .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJlZGl0bzp0ZXN0Ym9hcmQiXX0.-P6gjYlPP5I2zgSoVTlADdesVPfSXV-JXZQK5uh3Xwo",
-      )
+      .url(withToken(SERVER + "/boards/testboard", TOKENS.boardEditorTestboard))
       .waitForElementVisible("#menu");
     browser
-      .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJlZGl0bzp0ZXN0Ym9hcmQiXX0.-P6gjYlPP5I2zgSoVTlADdesVPfSXV-JXZQK5uh3Xwo",
-      )
+      .url(withToken(SERVER + "/boards/testboard", TOKENS.boardEditorTestboard))
       .waitForElementNotPresent("#toolID-Clear");
     //has editor JWT and  boardname provided and and not match to the board in the url
     browser
       .url(
-        SERVER +
-          "/boards/testboard123?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJlZGl0bzp0ZXN0Ym9hcmQiXX0.-P6gjYlPP5I2zgSoVTlADdesVPfSXV-JXZQK5uh3Xwo",
+        withToken(SERVER + "/boards/testboard123", TOKENS.boardEditorTestboard),
       )
       .waitForElementNotPresent("#menu");
     //is moderator and boardname contains ":"
     browser
       .url(
-        SERVER +
-          "/boards/test:board?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJtb2RlcmF0b3I6dGVzdDpib2FyZCJdfQ.LKYcDccheD2oXAMAemxSekDeowGsMl29CFkgJgwbkGE",
+        withToken(
+          SERVER + "/boards/test:board",
+          jsonwebtoken.sign(
+            { sub: "moderator-colon", roles: ["moderator:test:board"] },
+            AUTH_SECRET,
+          ),
+        ),
       )
       .waitForElementNotPresent("#menu");
     browser
       .url(
-        SERVER +
-          "/boards/testboard?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyb2xlcyI6WyJtb2RlcmF0b3I6dGVzdDpib2FyZCJdfQ.LKYcDccheD2oXAMAemxSekDeowGsMl29CFkgJgwbkGE",
+        withToken(
+          SERVER + "/boards/testboard",
+          jsonwebtoken.sign(
+            { sub: "moderator-colon", roles: ["moderator:test:board"] },
+            AUTH_SECRET,
+          ),
+        ),
       )
       .waitForElementNotPresent("#menu");
+    testReadOnlyBoardWithJwt(browser);
   }
   page.end();
 }


### PR DESCRIPTION
## Summary

This PR adds persisted read-only boards and enforces write permissions server-side.

## What changed

- store board metadata in the board JSON using `__wbo_meta__.readonly`
- block writes on read-only boards unless the connected user has `editor` or `moderator` access to that board
- block all writes on read-only boards when JWT auth is disabled
- keep board metadata out of normal board rendering and SVG export paths
- expose board state to the client and hide editing tools for read-only viewers
- update the README to clearly explain roles, board visibility, and how to switch a board between writable and read-only
- extend integration coverage for read-only behavior in authenticated and unauthenticated setups

## Why

Before this change, WBO had board access control and moderator/editor roles, but no way to make a board viewable without allowing arbitrary writes. This adds a board-level editability setting without introducing new roles.

## Impact

- operators can mark individual boards read-only by editing the persisted board file
- viewers can still access a read-only board when their token allows access
- only editors and moderators can modify a read-only board
- moderators still keep exclusive access to Clear

## Validation

- `npm test`
