### PR TITLE
[codex] Forbid giant shapes across tools

### DIFF
--- a/client-data/board.css
+++ b/client-data/board.css
@@ -185,6 +185,17 @@ svg {
   background: linear-gradient(#96e1ff, #36a2ff);
 }
 
+#menu .tool.disabledTool {
+  opacity: 0.45;
+  filter: grayscale(1);
+  cursor: not-allowed;
+}
+
+#menu .tool.disabledTool.curTool {
+  box-shadow: none;
+  background: inherit;
+}
+
 #menu .tool-icon {
   display: inline-block;
   text-align: center;

--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -40,6 +40,8 @@ Tools.i18n = (function i18n() {
 Tools.server_config = JSON.parse(document.getElementById("configuration").text);
 Tools.readOnlyToolNames = new Set(["Hand", "Grid", "Download", "Zoom"]);
 Tools.turnstileValidated = false;
+Tools.scale = 1.0;
+Tools.drawToolsAllowed = null;
 
 if (Tools.server_config.TURNSTILE_SITE_KEY) {
   var script = document.createElement("script");
@@ -103,6 +105,46 @@ Tools.showTurnstileWidget = function () {
   }
 };
 
+Tools.shouldDisableTool = function shouldDisableTool(toolName) {
+  return (
+    MessageCommon.isDrawTool(toolName) &&
+    !MessageCommon.isDrawToolAllowedAtScale(Tools.scale || 1)
+  );
+};
+
+Tools.canUseTool = function canUseTool(toolName) {
+  return (
+    Tools.shouldDisplayTool(toolName) && !Tools.shouldDisableTool(toolName)
+  );
+};
+
+Tools.syncToolDisabledState = function syncToolDisabledState(toolName) {
+  var toolElem = document.getElementById("toolID-" + toolName);
+  if (!toolElem) return;
+  var disabled = Tools.shouldDisableTool(toolName);
+  toolElem.classList.toggle("disabledTool", disabled);
+  toolElem.setAttribute("aria-disabled", disabled ? "true" : "false");
+};
+
+Tools.syncDrawToolAvailability = function syncDrawToolAvailability(force) {
+  var drawToolsAllowed = MessageCommon.isDrawToolAllowedAtScale(Tools.scale);
+  if (!force && drawToolsAllowed === Tools.drawToolsAllowed) return;
+  Tools.drawToolsAllowed = drawToolsAllowed;
+
+  Object.keys(Tools.list || {}).forEach(function (toolName) {
+    Tools.syncToolDisabledState(toolName);
+  });
+
+  if (
+    !drawToolsAllowed &&
+    Tools.curTool &&
+    MessageCommon.isDrawTool(Tools.curTool.name) &&
+    Tools.list.Hand
+  ) {
+    Tools.change("Hand");
+  }
+};
+
 Tools.setBoardState = function setBoardState(state) {
   state = state || {};
   Tools.boardState = {
@@ -121,6 +163,8 @@ Tools.setBoardState = function setBoardState(state) {
     if (!toolElem) return;
     toolElem.style.display = Tools.shouldDisplayTool(toolName) ? "" : "none";
   });
+
+  Tools.syncDrawToolAvailability(true);
 
   if (
     hideEditingTools &&
@@ -281,9 +325,11 @@ Tools.HTML = {
   },
   addTool: function (toolName, toolIcon, toolIconHTML, toolShortcut, oneTouch) {
     var callback = function () {
+      if (!Tools.canUseTool(toolName)) return;
       Tools.change(toolName);
     };
     this.addShortcut(toolShortcut, function () {
+      if (!Tools.canUseTool(toolName)) return;
       Tools.change(toolName);
       document.activeElement.blur && document.activeElement.blur();
     });
@@ -312,6 +358,7 @@ Tools.HTML = {
         secondaryIcon.src = Tools.list[toolName].secondary.icon;
         toolIconElem.classList.add("primaryIcon");
       }
+      Tools.syncToolDisabledState(toolName);
     });
   },
   changeTool: function (oldToolName, newToolName) {
@@ -425,6 +472,8 @@ Tools.add = function (newTool) {
       newTool.oneTouch,
     );
   }
+
+  Tools.syncToolDisabledState(newTool.name);
 };
 
 Tools.change = function (toolName) {
@@ -432,6 +481,7 @@ Tools.change = function (toolName) {
   var oldTool = Tools.curTool;
   if (!newTool)
     throw new Error("Trying to select a tool that has never been added!");
+  if (Tools.shouldDisableTool(toolName)) return false;
   if (newTool === oldTool) {
     if (newTool.secondary) {
       newTool.secondary.active = !newTool.secondary.active;
@@ -471,6 +521,7 @@ Tools.change = function (toolName) {
 
   //Call the start callback of the new tool
   newTool.onstart(oldTool);
+  return true;
 };
 
 Tools.addToolListeners = function addToolListeners(tool) {
@@ -519,6 +570,7 @@ Tools.send = function (data, toolName) {
 
 Tools.drawAndSend = function (data, tool) {
   if (tool == null) tool = Tools.curTool;
+  if (tool && Tools.shouldDisableTool(tool.name)) return false;
   if (
     WBOMessageCommon.requiresTurnstile(Tools.boardName, tool.name) &&
     Tools.server_config.TURNSTILE_SITE_KEY &&
@@ -529,6 +581,7 @@ Tools.drawAndSend = function (data, tool) {
   }
   tool.draw(data, true);
   Tools.send(data, tool.name);
+  return true;
 };
 
 //Object containing the messages that have been received before the corresponding tool
@@ -690,7 +743,6 @@ function updateUnreadCount(m) {
 // List of hook functions that will be applied to messages before sending or drawing them
 Tools.messageHooks = [resizeCanvas, updateUnreadCount];
 
-Tools.scale = 1.0;
 var scaleTimeout = null;
 Tools.setScale = function setScale(scale) {
   var fullScale =
@@ -707,6 +759,7 @@ Tools.setScale = function setScale(scale) {
     Tools.svg.style.willChange = "auto";
   }, 1000);
   Tools.scale = scale;
+  Tools.syncDrawToolAvailability(false);
   return scale;
 };
 Tools.getScale = function getScale() {

--- a/client-data/js/message_common.js
+++ b/client-data/js/message_common.js
@@ -8,12 +8,22 @@
     MAX_SIZE: 50,
     MIN_OPACITY: 0.1,
     MAX_OPACITY: 1,
+    MIN_DRAW_ZOOM: 0.4,
+    GIANT_SHAPE_VIEWPORT_WIDTH: 1280,
+    GIANT_SHAPE_VIEWPORT_HEIGHT: 720,
     DEFAULT_MAX_BOARD_SIZE: 65536,
     MAX_TEXT_LENGTH: 280,
     COORDINATE_DECIMALS: 1,
     DEFAULT_MAX_CHILDREN: 192,
     MAX_ID_LENGTH: 128,
   };
+  var DRAW_TOOL_NAMES = [
+    "Pencil",
+    "Straight line",
+    "Rectangle",
+    "Ellipse",
+    "Text",
+  ];
 
   function toFiniteNumber(value) {
     var number = Number(value);
@@ -89,12 +99,205 @@
     return true;
   }
 
+  function isDrawTool(toolName) {
+    return DRAW_TOOL_NAMES.indexOf(toolName) !== -1;
+  }
+
+  function isDrawToolAllowedAtScale(scale) {
+    var numericScale = toFiniteNumber(scale);
+    return numericScale !== null && numericScale > LIMITS.MIN_DRAW_ZOOM;
+  }
+
+  function getMaxShapeSpan() {
+    return LIMITS.GIANT_SHAPE_VIEWPORT_WIDTH / LIMITS.MIN_DRAW_ZOOM;
+  }
+
+  function cloneBounds(bounds) {
+    if (!bounds) return null;
+    return {
+      minX: bounds.minX,
+      minY: bounds.minY,
+      maxX: bounds.maxX,
+      maxY: bounds.maxY,
+    };
+  }
+
+  function extendBoundsWithPoint(bounds, x, y) {
+    var pointX = toFiniteNumber(x);
+    var pointY = toFiniteNumber(y);
+    if (pointX === null || pointY === null) return cloneBounds(bounds);
+    if (!bounds) {
+      return {
+        minX: pointX,
+        minY: pointY,
+        maxX: pointX,
+        maxY: pointY,
+      };
+    }
+    return {
+      minX: Math.min(bounds.minX, pointX),
+      minY: Math.min(bounds.minY, pointY),
+      maxX: Math.max(bounds.maxX, pointX),
+      maxY: Math.max(bounds.maxY, pointY),
+    };
+  }
+
+  function getPencilBounds(item) {
+    if (!item || !Array.isArray(item._children) || item._children.length === 0)
+      return null;
+    return item._children.reduce(function extend(bounds, child) {
+      if (!child) return bounds;
+      return extendBoundsWithPoint(bounds, child.x, child.y);
+    }, null);
+  }
+
+  function getStraightShapeBounds(item) {
+    if (!item) return null;
+    var x1 = toFiniteNumber(item.x);
+    var y1 = toFiniteNumber(item.y);
+    var x2 = toFiniteNumber(item.x2);
+    var y2 = toFiniteNumber(item.y2);
+    if (x1 === null || y1 === null || x2 === null || y2 === null) return null;
+    return {
+      minX: Math.min(x1, x2),
+      minY: Math.min(y1, y2),
+      maxX: Math.max(x1, x2),
+      maxY: Math.max(y1, y2),
+    };
+  }
+
+  function getTextBounds(item) {
+    if (!item) return null;
+    var x = toFiniteNumber(item.x);
+    var y = toFiniteNumber(item.y);
+    var size = toFiniteNumber(item.size);
+    if (x === null || y === null || size === null) return null;
+    return {
+      minX: x,
+      minY: y - size,
+      maxX: x + size,
+      maxY: y,
+    };
+  }
+
+  function getLocalGeometryBounds(item) {
+    if (!item || typeof item.tool !== "string") return null;
+    switch (item.tool) {
+      case "Pencil":
+        return getPencilBounds(item);
+      case "Straight line":
+      case "Rectangle":
+      case "Ellipse":
+        return getStraightShapeBounds(item);
+      case "Text":
+        return getTextBounds(item);
+      default:
+        return null;
+    }
+  }
+
+  function applyTransformToPoint(point, transform) {
+    var a = toFiniteNumber(transform && transform.a);
+    var b = toFiniteNumber(transform && transform.b);
+    var c = toFiniteNumber(transform && transform.c);
+    var d = toFiniteNumber(transform && transform.d);
+    var e = toFiniteNumber(transform && transform.e);
+    var f = toFiniteNumber(transform && transform.f);
+    if (
+      a === null ||
+      b === null ||
+      c === null ||
+      d === null ||
+      e === null ||
+      f === null
+    ) {
+      return null;
+    }
+    return {
+      x: a * point.x + c * point.y + e,
+      y: b * point.x + d * point.y + f,
+    };
+  }
+
+  function applyTransformToBounds(bounds, transform) {
+    if (!bounds) return null;
+    if (!transform) return cloneBounds(bounds);
+
+    var isTranslationOnly =
+      transform.a === 1 &&
+      transform.b === 0 &&
+      transform.c === 0 &&
+      transform.d === 1;
+    if (isTranslationOnly) {
+      var translateX = toFiniteNumber(transform.e);
+      var translateY = toFiniteNumber(transform.f);
+      if (translateX === null || translateY === null) return null;
+      return {
+        minX: bounds.minX + translateX,
+        minY: bounds.minY + translateY,
+        maxX: bounds.maxX + translateX,
+        maxY: bounds.maxY + translateY,
+      };
+    }
+
+    var points = [
+      { x: bounds.minX, y: bounds.minY },
+      { x: bounds.maxX, y: bounds.minY },
+      { x: bounds.minX, y: bounds.maxY },
+      { x: bounds.maxX, y: bounds.maxY },
+    ];
+    var transformed = null;
+    for (var i = 0; i < points.length; i++) {
+      var point = applyTransformToPoint(points[i], transform);
+      if (point === null) return null;
+      transformed = extendBoundsWithPoint(transformed, point.x, point.y);
+    }
+    return transformed;
+  }
+
+  function getEffectiveGeometryBounds(item) {
+    if (!item) return null;
+    return applyTransformToBounds(getLocalGeometryBounds(item), item.transform);
+  }
+
+  function getBoundsWidth(bounds) {
+    return bounds ? bounds.maxX - bounds.minX : 0;
+  }
+
+  function getBoundsHeight(bounds) {
+    return bounds ? bounds.maxY - bounds.minY : 0;
+  }
+
+  function isBoundsTooLarge(bounds) {
+    if (!bounds) return false;
+    var maxShapeSpan = getMaxShapeSpan();
+    return (
+      getBoundsWidth(bounds) > maxShapeSpan ||
+      getBoundsHeight(bounds) > maxShapeSpan
+    );
+  }
+
+  function isGeometryTooLarge(item) {
+    return isBoundsTooLarge(getEffectiveGeometryBounds(item));
+  }
+
   return {
+    DRAW_TOOL_NAMES: DRAW_TOOL_NAMES,
     LIMITS: LIMITS,
+    applyTransformToBounds: applyTransformToBounds,
     clampOpacity: clampOpacity,
     clampCoord: clampCoord,
     clampSize: clampSize,
+    extendBoundsWithPoint: extendBoundsWithPoint,
+    getEffectiveGeometryBounds: getEffectiveGeometryBounds,
+    getLocalGeometryBounds: getLocalGeometryBounds,
+    getMaxShapeSpan: getMaxShapeSpan,
+    getPencilBounds: getPencilBounds,
     isFiniteTransformNumber: isFiniteTransformNumber,
+    isBoundsTooLarge: isBoundsTooLarge,
+    isDrawTool: isDrawTool,
+    isDrawToolAllowedAtScale: isDrawToolAllowedAtScale,
+    isGeometryTooLarge: isGeometryTooLarge,
     normalizeColor: normalizeColor,
     normalizeFiniteNumber: normalizeFiniteNumber,
     normalizeId: normalizeId,

--- a/client-data/js/message_common.js
+++ b/client-data/js/message_common.js
@@ -171,11 +171,12 @@
     var x = toFiniteNumber(item.x);
     var y = toFiniteNumber(item.y);
     var size = toFiniteNumber(item.size);
-    if (x === null || y === null || size === null) return null;
+    var len = toFiniteNumber(item.txt && item.txt.length);
+    if (x === null || y === null || size === null || len === null) return null;
     return {
       minX: x,
       minY: y - size,
-      maxX: x + size,
+      maxX: x + size * len,
       maxY: y,
     };
   }

--- a/server/boardData.js
+++ b/server/boardData.js
@@ -32,6 +32,7 @@ var nativeFs = require("node:fs"),
     normalizeStoredChildPoint,
     normalizeStoredItem,
   } = require("./message_validation.js"),
+  MessageCommon = require("../client-data/js/message_common.js"),
   path = require("node:path"),
   config = require("./configuration.js"),
   Mutex = require("async-mutex").Mutex;
@@ -133,10 +134,121 @@ class BoardData {
     this.lastSaveDate = Date.now();
     this.users = new Set();
     this.saveMutex = new Mutex();
+    this.localBoundsCache = new Map();
   }
 
   isReadOnly() {
     return this.metadata.readonly === true;
+  }
+
+  cloneBounds(bounds) {
+    return bounds
+      ? {
+          minX: bounds.minX,
+          minY: bounds.minY,
+          maxX: bounds.maxX,
+          maxY: bounds.maxY,
+        }
+      : null;
+  }
+
+  cacheLocalBounds(id, bounds) {
+    if (bounds) {
+      this.localBoundsCache.set(id, this.cloneBounds(bounds));
+    } else {
+      this.localBoundsCache.delete(id);
+    }
+  }
+
+  getLocalBounds(id, item) {
+    const target = item || this.board[id];
+    if (!target) return null;
+
+    const cachedBounds = this.localBoundsCache.get(id);
+    if (cachedBounds) return this.cloneBounds(cachedBounds);
+
+    const bounds = MessageCommon.getLocalGeometryBounds(target);
+    this.cacheLocalBounds(id, bounds);
+    return bounds;
+  }
+
+  validateStoredCandidate(id, data) {
+    const normalized = normalizeStoredItem(data, id);
+    if (!normalized.ok) return normalized;
+    return {
+      ok: true,
+      value: normalized.value,
+      localBounds: MessageCommon.getLocalGeometryBounds(normalized.value),
+    };
+  }
+
+  isCandidateTooLarge(candidate, localBounds) {
+    const effectiveBounds = MessageCommon.applyTransformToBounds(
+      localBounds,
+      candidate && candidate.transform,
+    );
+    return MessageCommon.isBoundsTooLarge(effectiveBounds);
+  }
+
+  canStore(id, data) {
+    return this.validateStoredCandidate(id, data).ok;
+  }
+
+  canUpdate(id, updateData) {
+    const obj = this.board[id];
+    if (typeof obj !== "object") return false;
+
+    const candidate = Object.assign({}, obj, updateData);
+    const localBounds =
+      obj.tool === "Pencil" && updateData.transform !== undefined
+        ? this.getLocalBounds(id, obj)
+        : MessageCommon.getLocalGeometryBounds(candidate);
+    return !this.isCandidateTooLarge(candidate, localBounds);
+  }
+
+  canAddChild(parentId, child) {
+    const obj = this.board[parentId];
+    if (!obj || obj.tool !== "Pencil") return false;
+
+    const normalizedChild = normalizeStoredChildPoint(child);
+    if (!normalizedChild.ok) return false;
+    if (
+      Array.isArray(obj._children) &&
+      obj._children.length >= config.MAX_CHILDREN
+    )
+      return false;
+
+    const nextBounds = MessageCommon.extendBoundsWithPoint(
+      this.getLocalBounds(parentId, obj),
+      normalizedChild.value.x,
+      normalizedChild.value.y,
+    );
+    return !this.isCandidateTooLarge(obj, nextBounds);
+  }
+
+  canCopy(id, data) {
+    const obj = this.board[id];
+    if (!obj) return false;
+    return this.validateStoredCandidate(data.newid, structuredClone(obj)).ok;
+  }
+
+  canProcessMessage(message) {
+    let id = message.id;
+    switch (message.type) {
+      case "delete":
+      case "clear":
+        return true;
+      case "update":
+        return id
+          ? this.canUpdate(id, filterUpdatableFields(message.tool, message))
+          : false;
+      case "copy":
+        return id ? this.canCopy(id, message) : false;
+      case "child":
+        return this.canAddChild(message.parent, message);
+      default:
+        return id ? this.canStore(id, message) : false;
+    }
   }
 
   /** Adds data to the board
@@ -146,9 +258,12 @@ class BoardData {
   set(id, data) {
     //KISS
     data.time = Date.now();
-    this.board[id] = data;
-    this.normalizeStoredElement(id);
+    const validated = this.validateStoredCandidate(id, data);
+    if (!validated.ok) return false;
+    this.board[id] = validated.value;
+    this.cacheLocalBounds(id, validated.localBounds);
     this.delaySave();
+    return true;
   }
 
   /** Adds a child to an element that is already in the board
@@ -158,16 +273,20 @@ class BoardData {
    */
   addChild(parentId, child) {
     var obj = this.board[parentId];
-    if (typeof obj !== "object") return false;
+    if (typeof obj !== "object" || obj.tool !== "Pencil") return false;
     const normalizedChild = normalizeStoredChildPoint(child);
     if (!normalizedChild.ok) return false;
-    if (Array.isArray(obj._children)) {
-      if (obj._children.length >= config.MAX_CHILDREN) return false;
-      obj._children.push(normalizedChild.value);
-    } else {
-      obj._children = [normalizedChild.value];
-    }
-    this.normalizeStoredElement(parentId);
+    const children = Array.isArray(obj._children) ? obj._children : [];
+    if (children.length >= config.MAX_CHILDREN) return false;
+    const nextBounds = MessageCommon.extendBoundsWithPoint(
+      this.getLocalBounds(parentId, obj),
+      normalizedChild.value.x,
+      normalizedChild.value.y,
+    );
+    if (this.isCandidateTooLarge(obj, nextBounds)) return false;
+    if (!Array.isArray(obj._children)) obj._children = children;
+    obj._children.push(normalizedChild.value);
+    this.cacheLocalBounds(parentId, nextBounds);
     this.delaySave();
     return true;
   }
@@ -182,16 +301,14 @@ class BoardData {
     var updateData = filterUpdatableFields(tool, data);
 
     var obj = this.board[id];
-    if (typeof obj === "object") {
-      for (var i in updateData) {
-        if (updateData[i] !== undefined) obj[i] = updateData[i];
-      }
-      this.normalizeStoredElement(id);
-    } else if (create || obj !== undefined) {
-      this.board[id] = updateData;
-      this.normalizeStoredElement(id);
+    if (typeof obj !== "object") return false;
+    if (!this.canUpdate(id, updateData)) return false;
+    for (var i in updateData) {
+      if (updateData[i] !== undefined) obj[i] = updateData[i];
     }
+    this.cacheLocalBounds(id, MessageCommon.getLocalGeometryBounds(obj));
     this.delaySave();
+    return true;
   }
 
   /** Copy elements in the board
@@ -203,19 +320,25 @@ class BoardData {
     var newid = data.newid;
     if (obj) {
       var newobj = structuredClone(obj);
-      this.board[newid] = newobj;
-      this.normalizeStoredElement(newid);
+      const validated = this.validateStoredCandidate(newid, newobj);
+      if (!validated.ok) return false;
+      this.board[newid] = validated.value;
+      this.cacheLocalBounds(newid, validated.localBounds);
     } else {
       log("Copied object does not exist in board.", { object: id });
+      return false;
     }
     this.delaySave();
+    return true;
   }
 
   /** Clear the board of all data
    */
   clear() {
     this.board = {};
+    this.localBoundsCache.clear();
     this.delaySave();
+    return true;
   }
 
   /** Removes data from the board
@@ -224,7 +347,9 @@ class BoardData {
   delete(id) {
     //KISS
     delete this.board[id];
+    this.localBoundsCache.delete(id);
     this.delaySave();
+    return true;
   }
 
   /** Process a batch of messages
@@ -237,13 +362,93 @@ class BoardData {
    * @param {BoardMessage[]} children array of messages to be delegated to the other methods
    */
   processMessageBatch(children, parentMessage) {
-    for (const childMessage of children) {
-      const message =
-        parentMessage && childMessage.tool === undefined
-          ? Object.assign({ tool: parentMessage.tool }, childMessage)
-          : childMessage;
-      this.processMessage(message);
+    const messages = children.map((childMessage) =>
+      parentMessage && childMessage.tool === undefined
+        ? Object.assign({ tool: parentMessage.tool }, childMessage)
+        : childMessage,
+    );
+
+    let boardCleared = false;
+    const shadowItems = new Map();
+    const readShadowItem = (id) =>
+      shadowItems.has(id)
+        ? shadowItems.get(id)
+        : boardCleared
+          ? undefined
+          : this.board[id];
+
+    for (const message of messages) {
+      const id = message.id;
+      switch (message.type) {
+        case "clear":
+          boardCleared = true;
+          shadowItems.clear();
+          break;
+        case "delete":
+          if (id) shadowItems.set(id, undefined);
+          break;
+        case "update": {
+          if (!id) return false;
+          const current = readShadowItem(id);
+          if (typeof current !== "object") return false;
+          const updateData = filterUpdatableFields(message.tool, message);
+          const candidate = Object.assign({}, current, updateData);
+          const localBounds =
+            current.tool === "Pencil" && updateData.transform !== undefined
+              ? MessageCommon.getLocalGeometryBounds(current)
+              : MessageCommon.getLocalGeometryBounds(candidate);
+          if (this.isCandidateTooLarge(candidate, localBounds)) return false;
+          shadowItems.set(id, candidate);
+          break;
+        }
+        case "copy": {
+          if (!id) return false;
+          const current = readShadowItem(id);
+          if (!current) return false;
+          const validated = this.validateStoredCandidate(
+            message.newid,
+            structuredClone(current),
+          );
+          if (!validated.ok) return false;
+          shadowItems.set(message.newid, validated.value);
+          break;
+        }
+        case "child": {
+          const current = readShadowItem(message.parent);
+          if (!current || current.tool !== "Pencil") return false;
+          const normalizedChild = normalizeStoredChildPoint(message);
+          if (!normalizedChild.ok) return false;
+          const currentChildren = Array.isArray(current._children)
+            ? current._children.slice()
+            : [];
+          if (currentChildren.length >= config.MAX_CHILDREN) return false;
+          const nextBounds = MessageCommon.extendBoundsWithPoint(
+            MessageCommon.getLocalGeometryBounds(current),
+            normalizedChild.value.x,
+            normalizedChild.value.y,
+          );
+          if (this.isCandidateTooLarge(current, nextBounds)) return false;
+          currentChildren.push(normalizedChild.value);
+          shadowItems.set(
+            message.parent,
+            Object.assign({}, current, { _children: currentChildren }),
+          );
+          break;
+        }
+        default: {
+          if (!id) return false;
+          const validated = this.validateStoredCandidate(id, message);
+          if (!validated.ok) return false;
+          shadowItems.set(id, validated.value);
+          break;
+        }
+      }
     }
+
+    for (const message of messages) {
+      if (!this.processMessage(message)) return false;
+    }
+    return true;
   }
 
   /** Process a single message
@@ -255,26 +460,22 @@ class BoardData {
     let id = message.id;
     switch (message.type) {
       case "delete":
-        if (id) this.delete(id);
-        break;
+        return id ? this.delete(id) : false;
       case "update":
-        if (id) this.update(id, message);
-        break;
+        return id ? this.update(id, message) : false;
       case "copy":
-        if (id) this.copy(id, message);
-        break;
+        return id ? this.copy(id, message) : false;
       case "child":
         // We don't need to store 'type', 'parent', and 'tool' for each child. They will be rehydrated from the parent on the client side
         const { parent, type, tool, ...childData } = message;
-        this.addChild(parent, childData);
-        break;
+        return this.addChild(parent, childData);
       case "clear":
-        this.clear();
-        break;
+        return this.clear();
       default:
         //Add data
-        if (id) this.set(id, message);
-        else console.error("Invalid message: ", message);
+        if (id) return this.set(id, message);
+        console.error("Invalid message: ", message);
+        return false;
     }
   }
 
@@ -365,13 +566,15 @@ class BoardData {
   }
 
   normalizeStoredElement(id) {
-    const normalized = normalizeStoredItem(this.board[id], id);
-    if (!normalized.ok) {
+    const validated = this.validateStoredCandidate(id, this.board[id]);
+    if (!validated.ok) {
       delete this.board[id];
+      this.localBoundsCache.delete(id);
       return false;
     }
 
-    this.board[id] = normalized.value;
+    this.board[id] = validated.value;
+    this.cacheLocalBounds(id, validated.localBounds);
     return true;
   }
 

--- a/server/boardData.js
+++ b/server/boardData.js
@@ -224,6 +224,23 @@ class BoardData {
     return !this.isCandidateTooLarge(candidate, localBounds);
   }
 
+  isIncrementalUpdateTooLarge(id, obj, updateData) {
+    if (obj.tool === "Pencil") {
+      const nextBounds = MessageCommon.extendBoundsWithPoint(
+        this.getLocalBounds(id, obj),
+        updateData.x,
+        updateData.y,
+      );
+      return this.isCandidateTooLarge(obj, nextBounds);
+    }
+    if (obj.tool === "Text") {
+      const candidate = Object.assign({}, obj, { txt: updateData.txt });
+      const nextBounds = MessageCommon.getLocalGeometryBounds(candidate);
+      return this.isCandidateTooLarge(candidate, nextBounds);
+    }
+    return false;
+  }
+
   canAddChild(parentId, child) {
     const obj = this.board[parentId];
     if (!obj || obj.tool !== "Pencil") return false;
@@ -236,12 +253,11 @@ class BoardData {
     )
       return false;
 
-    const nextBounds = MessageCommon.extendBoundsWithPoint(
-      this.getLocalBounds(parentId, obj),
-      normalizedChild.value.x,
-      normalizedChild.value.y,
+    return !this.isIncrementalUpdateTooLarge(
+      parentId,
+      obj,
+      normalizedChild.value,
     );
-    return !this.isCandidateTooLarge(obj, nextBounds);
   }
 
   canCopy(id, data) {

--- a/server/boardData.js
+++ b/server/boardData.js
@@ -190,6 +190,24 @@ class BoardData {
     return MessageCommon.isBoundsTooLarge(effectiveBounds);
   }
 
+  hasZeroLocalExtent(item, id) {
+    const bounds = this.getLocalBounds(id, item);
+    if (!bounds) return false;
+    return bounds.minX === bounds.maxX && bounds.minY === bounds.maxY;
+  }
+
+  shouldDropSeedShapeOnRejectedUpdate(tool, item, id) {
+    return (
+      (tool === "Straight line" ||
+        tool === "Rectangle" ||
+        tool === "Ellipse") &&
+      item &&
+      item.tool === tool &&
+      this.hasZeroLocalExtent(item, id) &&
+      item.transform === undefined
+    );
+  }
+
   canStore(id, data) {
     return this.validateStoredCandidate(id, data).ok;
   }
@@ -302,7 +320,13 @@ class BoardData {
 
     var obj = this.board[id];
     if (typeof obj !== "object") return false;
-    if (!this.canUpdate(id, updateData)) return false;
+    if (!this.canUpdate(id, updateData)) {
+      if (this.shouldDropSeedShapeOnRejectedUpdate(obj.tool, obj, id)) {
+        delete this.board[id];
+        this.localBoundsCache.delete(id);
+      }
+      return false;
+    }
     for (var i in updateData) {
       if (updateData[i] !== undefined) obj[i] = updateData[i];
     }

--- a/server/message_validation.js
+++ b/server/message_validation.js
@@ -406,7 +406,12 @@ function normalizeIncomingMessage(raw) {
   const schema = toolSchemas && toolSchemas[raw.type];
   if (!schema) return rejected("invalid tool/type");
 
-  return normalizeObject(raw, schema);
+  const normalized = normalizeObject(raw, schema);
+  if (!normalized.ok) return normalized;
+  if (MessageCommon.isGeometryTooLarge(normalized.value)) {
+    return rejected("shape too large");
+  }
+  return normalized;
 }
 
 function normalizeStoredChildPoint(raw) {
@@ -439,6 +444,10 @@ function normalizeStoredItem(raw, storedId) {
       children.push(child.value);
     }
     if (children.length) normalized.value._children = children;
+  }
+
+  if (MessageCommon.isGeometryTooLarge(normalized.value)) {
+    return rejected("shape too large");
   }
 
   return normalized;

--- a/server/message_validation.js
+++ b/server/message_validation.js
@@ -408,7 +408,10 @@ function normalizeIncomingMessage(raw) {
 
   const normalized = normalizeObject(raw, schema);
   if (!normalized.ok) return normalized;
-  if (MessageCommon.isGeometryTooLarge(normalized.value)) {
+  if (
+    normalized.value.type !== "update" &&
+    MessageCommon.isGeometryTooLarge(normalized.value)
+  ) {
     return rejected("shape too large");
   }
   return normalized;

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -426,7 +426,14 @@ function handleSocketConnection(socket) {
       }
 
       // Save the message in the board
-      handleMessage(board, cloneMessageForPersistence(data), socket);
+      if (!handleMessage(board, cloneMessageForPersistence(data), socket)) {
+        log("BOARD_MESSAGE_REJECTED", {
+          board: board.name,
+          tool: data.tool,
+          type: data.type,
+        });
+        return;
+      }
 
       //Send data to all other users connected on the same board
       socket.broadcast.to(boardName).emit("broadcast", data);
@@ -468,16 +475,16 @@ async function unloadBoard(boardName) {
 function handleMessage(board, message, socket) {
   if (message.tool === "Cursor") {
     message.socket = socket.id;
-  } else {
-    saveHistory(board, message);
+    return true;
   }
+  return saveHistory(board, message);
 }
 
 function saveHistory(board, message) {
   if (!(message.tool || message.type === "child") && !message._children) {
     console.error("Received a badly formatted message (no tool). ", message);
   }
-  board.processMessage(message);
+  return board.processMessage(message);
 }
 
 function generateUID(prefix, suffix) {

--- a/test-node/board_data.test.js
+++ b/test-node/board_data.test.js
@@ -125,6 +125,107 @@ test("BoardData.addChild enforces MAX_CHILDREN on stored strokes", async functio
   });
 });
 
+test("BoardData rejects the first pencil child that makes a stroke oversized", function () {
+  const BoardData = require(BOARD_DATA_PATH).BoardData;
+  const board = disableSaves(new BoardData("oversized-pencil-board"));
+
+  assert.equal(
+    board.set("line-1", {
+      tool: "Pencil",
+      type: "line",
+      id: "line-1",
+      color: "#123456",
+      size: 4,
+    }),
+    true,
+  );
+
+  assert.equal(board.addChild("line-1", { x: 0, y: 0 }), true);
+  assert.equal(board.addChild("line-1", { x: 3199, y: 0 }), true);
+  assert.equal(board.addChild("line-1", { x: 3201, y: 0 }), false);
+  assert.deepEqual(board.get("line-1")._children, [
+    { x: 0, y: 0 },
+    { x: 3199, y: 0 },
+  ]);
+});
+
+test("BoardData rejects transform updates that make a stored shape oversized", function () {
+  const BoardData = require(BOARD_DATA_PATH).BoardData;
+  const board = disableSaves(new BoardData("oversized-transform-board"));
+
+  board.processMessage({
+    tool: "Rectangle",
+    type: "rect",
+    id: "rect-1",
+    color: "#112233",
+    size: 4,
+    x: 0,
+    y: 0,
+    x2: 1000,
+    y2: 1000,
+  });
+
+  assert.equal(
+    board.processMessage({
+      tool: "Hand",
+      type: "update",
+      id: "rect-1",
+      transform: { a: 4, b: 0, c: 0, d: 4, e: 0, f: 0 },
+    }),
+    false,
+  );
+  assert.equal(board.get("rect-1").transform, undefined);
+});
+
+test("BoardData rejects hand batches atomically when one transform is oversized", function () {
+  const BoardData = require(BOARD_DATA_PATH).BoardData;
+  const board = disableSaves(new BoardData("atomic-hand-batch-board"));
+
+  board.processMessage({
+    tool: "Rectangle",
+    type: "rect",
+    id: "rect-1",
+    color: "#112233",
+    size: 4,
+    x: 0,
+    y: 0,
+    x2: 1000,
+    y2: 1000,
+  });
+  board.processMessage({
+    tool: "Rectangle",
+    type: "rect",
+    id: "rect-2",
+    color: "#112233",
+    size: 4,
+    x: 0,
+    y: 0,
+    x2: 100,
+    y2: 100,
+  });
+
+  assert.equal(
+    board.processMessage({
+      tool: "Hand",
+      _children: [
+        {
+          type: "update",
+          id: "rect-1",
+          transform: { a: 4, b: 0, c: 0, d: 4, e: 0, f: 0 },
+        },
+        {
+          type: "update",
+          id: "rect-2",
+          transform: { a: 1, b: 0, c: 0, d: 1, e: 25, f: 30 },
+        },
+      ],
+    }),
+    false,
+  );
+  assert.equal(board.get("rect-1").transform, undefined);
+  assert.equal(board.get("rect-2").transform, undefined);
+});
+
 test("BoardData.clean keeps the newest items when trimming history", async function () {
   await withEnv({ WBO_MAX_ITEM_COUNT: "2" }, async function () {
     const BoardData = require(BOARD_DATA_PATH).BoardData;
@@ -171,17 +272,7 @@ test("BoardData.load normalizes stored board items from disk", async function ()
 
     const board = await BoardData.load("normalized-load");
 
-    assert.deepEqual(board.get("bad1"), {
-      tool: "Rectangle",
-      type: "rect",
-      id: "bad1",
-      color: "#abcdef",
-      size: 50,
-      x: 0,
-      y: 20.3,
-      x2: 65536,
-      y2: 40,
-    });
+    assert.equal(board.get("bad1"), undefined);
     assert.equal(board.get("bad2"), undefined);
   });
 });

--- a/test-node/board_data.test.js
+++ b/test-node/board_data.test.js
@@ -177,6 +177,40 @@ test("BoardData rejects transform updates that make a stored shape oversized", f
   assert.equal(board.get("rect-1").transform, undefined);
 });
 
+test("BoardData drops zero-size seed shapes after an oversized update is rejected", function () {
+  const BoardData = require(BOARD_DATA_PATH).BoardData;
+  const board = disableSaves(new BoardData("oversized-seed-shape-board"));
+
+  assert.equal(
+    board.processMessage({
+      tool: "Rectangle",
+      type: "rect",
+      id: "rect-1",
+      color: "#112233",
+      size: 4,
+      x: 10,
+      y: 10,
+      x2: 10,
+      y2: 10,
+    }),
+    true,
+  );
+
+  assert.equal(
+    board.processMessage({
+      tool: "Rectangle",
+      type: "update",
+      id: "rect-1",
+      x: 10,
+      y: 10,
+      x2: 4015,
+      y2: 30,
+    }),
+    false,
+  );
+  assert.equal(board.get("rect-1"), undefined);
+});
+
 test("BoardData rejects hand batches atomically when one transform is oversized", function () {
   const BoardData = require(BOARD_DATA_PATH).BoardData;
   const board = disableSaves(new BoardData("atomic-hand-batch-board"));

--- a/test-node/message_common.test.js
+++ b/test-node/message_common.test.js
@@ -41,3 +41,19 @@ test("shared geometry helpers grow pencil bounds incrementally", function () {
     maxY: 25,
   });
 });
+
+test("getLocalGeometryBounds measures text", function () {
+  const bounds = MessageCommon.getLocalGeometryBounds({
+    tool: "Text",
+    x: 100,
+    y: 200,
+    txt: "0123456789",
+    size: 55,
+  });
+  assert.deepEqual(bounds, {
+    minX: 100,
+    minY: 200 - 55,
+    maxX: 100 + 10 * 55,
+    maxY: 200,
+  });
+});

--- a/test-node/message_common.test.js
+++ b/test-node/message_common.test.js
@@ -1,0 +1,43 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const MessageCommon = require("../client-data/js/message_common.js");
+
+test("shared giant-shape policy exposes the draw zoom threshold", function () {
+  assert.equal(MessageCommon.getMaxShapeSpan(), 3200);
+  assert.equal(MessageCommon.isDrawToolAllowedAtScale(0.4), false);
+  assert.equal(MessageCommon.isDrawToolAllowedAtScale(0.41), true);
+});
+
+test("shared geometry helpers apply transforms to bounds", function () {
+  const bounds = MessageCommon.applyTransformToBounds(
+    {
+      minX: 0,
+      minY: 0,
+      maxX: 100,
+      maxY: 50,
+    },
+    { a: 2, b: 0, c: 0, d: 3, e: 10, f: 20 },
+  );
+
+  assert.deepEqual(bounds, {
+    minX: 10,
+    minY: 20,
+    maxX: 210,
+    maxY: 170,
+  });
+});
+
+test("shared geometry helpers grow pencil bounds incrementally", function () {
+  let bounds = null;
+  bounds = MessageCommon.extendBoundsWithPoint(bounds, 10, 20);
+  bounds = MessageCommon.extendBoundsWithPoint(bounds, 100, 5);
+  bounds = MessageCommon.extendBoundsWithPoint(bounds, -5, 25);
+
+  assert.deepEqual(bounds, {
+    minX: -5,
+    minY: 5,
+    maxX: 100,
+    maxY: 25,
+  });
+});

--- a/test-node/message_validation.test.js
+++ b/test-node/message_validation.test.js
@@ -53,6 +53,48 @@ test("normalizeIncomingMessage rejects malformed hand batches atomically", funct
   assert.match(normalized.reason, /_children\[1\]/);
 });
 
+test("normalizeIncomingMessage rejects oversized live shapes", function () {
+  const messageValidation = require(MESSAGE_VALIDATION_PATH);
+  const normalized = messageValidation.normalizeIncomingMessage({
+    tool: "Rectangle",
+    type: "rect",
+    id: "rect-big",
+    color: "#123456",
+    size: 4,
+    x: 0,
+    y: 0,
+    x2: 4000,
+    y2: 20,
+  });
+
+  assert.deepEqual(normalized, {
+    ok: false,
+    reason: "shape too large",
+  });
+});
+
+test("normalizeStoredItem rejects transformed oversized shapes", function () {
+  const messageValidation = require(MESSAGE_VALIDATION_PATH);
+  const normalized = messageValidation.normalizeStoredItem(
+    {
+      tool: "Rectangle",
+      color: "#123456",
+      size: 4,
+      x: 0,
+      y: 0,
+      x2: 1000,
+      y2: 1000,
+      transform: { a: 4, b: 0, c: 0, d: 4, e: 0, f: 0 },
+    },
+    "rect-scaled",
+  );
+
+  assert.deepEqual(normalized, {
+    ok: false,
+    reason: "shape too large",
+  });
+});
+
 test("normalizeStoredItem sanitizes stored pencil children before replay", async function () {
   await withEnv({ WBO_MAX_CHILDREN: "2" }, async function () {
     const messageValidation = require(MESSAGE_VALIDATION_PATH);

--- a/test-node/message_validation.test.js
+++ b/test-node/message_validation.test.js
@@ -73,6 +73,61 @@ test("normalizeIncomingMessage rejects oversized live shapes", function () {
   });
 });
 
+test("normalizeIncomingMessage allows text updates but truncates long text", function () {
+  const messageValidation = require(MESSAGE_VALIDATION_PATH);
+  const longText = "A".repeat(500);
+  const normalized = messageValidation.normalizeIncomingMessage({
+    tool: "Text",
+    type: "update",
+    id: "text-1",
+    txt: longText,
+  });
+
+  assert.equal(normalized.ok, true);
+  assert.equal(normalized.value.txt.length, 280); // MAX_TEXT_LENGTH
+});
+
+test("normalizeStoredItem rejects oversized stored text", function () {
+  const messageValidation = require(MESSAGE_VALIDATION_PATH);
+  const normalized = messageValidation.normalizeStoredItem(
+    {
+      tool: "Text",
+      color: "#000000",
+      size: 50,
+      x: 0,
+      y: 0,
+      txt: "A".repeat(100), // Width = 50 * 100 = 5000 > 3200 limit
+    },
+    "text-big",
+  );
+
+  assert.deepEqual(normalized, {
+    ok: false,
+    reason: "shape too large",
+  });
+});
+
+test("normalizeStoredItem rejects oversized stored pencil", function () {
+  const messageValidation = require(MESSAGE_VALIDATION_PATH);
+  const normalized = messageValidation.normalizeStoredItem(
+    {
+      tool: "Pencil",
+      color: "#000000",
+      size: 4,
+      _children: [
+        { x: 0, y: 0 },
+        { x: 4000, y: 4000 },
+      ],
+    },
+    "pencil-big",
+  );
+
+  assert.deepEqual(normalized, {
+    ok: false,
+    reason: "shape too large",
+  });
+});
+
 test("normalizeStoredItem rejects transformed oversized shapes", function () {
   const messageValidation = require(MESSAGE_VALIDATION_PATH);
   const normalized = messageValidation.normalizeStoredItem(

--- a/tests/interaction.test.js
+++ b/tests/interaction.test.js
@@ -165,6 +165,70 @@ module.exports = {
       .end();
   },
 
+  "Test Draw Tools Disable At Giant Shape Zoom Threshold"(browser) {
+    const board = browser.page.board();
+    browser.url(
+      serverUrl + "/boards/zoom-threshold-test?lang=en&" + tokenQuery,
+    );
+
+    board
+      .waitForElementVisible("#toolID-Hand")
+      .waitForElementVisible("#toolID-Pencil")
+      .click("#toolID-Pencil")
+      .assert.hasClass("#toolID-Pencil", "curTool")
+      .execute(
+        function () {
+          Tools.setScale(0.4);
+          return {
+            currentTool: Tools.curTool && Tools.curTool.name,
+            pencilDisabled: document
+              .getElementById("toolID-Pencil")
+              .classList.contains("disabledTool"),
+            rectDisabled: document
+              .getElementById("toolID-Rectangle")
+              .classList.contains("disabledTool"),
+          };
+        },
+        [],
+        function (result) {
+          browser.assert.equal(result.value.currentTool, "Hand");
+          browser.assert.equal(result.value.pencilDisabled, true);
+          browser.assert.equal(result.value.rectDisabled, true);
+        },
+      )
+      .click("#toolID-Pencil")
+      .execute(
+        function () {
+          return {
+            currentTool: Tools.curTool && Tools.curTool.name,
+            changeResult: Tools.change("Pencil"),
+          };
+        },
+        [],
+        function (result) {
+          browser.assert.equal(result.value.currentTool, "Hand");
+          browser.assert.equal(result.value.changeResult, false);
+        },
+      )
+      .execute(
+        function () {
+          Tools.setScale(0.5);
+          return {
+            pencilDisabled: document
+              .getElementById("toolID-Pencil")
+              .classList.contains("disabledTool"),
+          };
+        },
+        [],
+        function (result) {
+          browser.assert.equal(result.value.pencilDisabled, false);
+        },
+      )
+      .click("#toolID-Pencil")
+      .assert.hasClass("#toolID-Pencil", "curTool")
+      .end();
+  },
+
   "Test Download Exports SVG Content"(browser) {
     const board = browser.page.board();
     browser.perform(async function (done) {

--- a/tests/interaction.test.js
+++ b/tests/interaction.test.js
@@ -1,4 +1,9 @@
-const { setup, teardown, writeBoard } = require("./lib/test_helper.js");
+const {
+  setup,
+  teardown,
+  writeBoard,
+  readStoredBoard,
+} = require("./lib/test_helper.js");
 
 let serverProcess, dataPath, serverUrl, tokenQuery;
 
@@ -196,9 +201,65 @@ module.exports = {
           browser.assert.equal(result.value.rectDisabled, true);
         },
       )
-      .click("#toolID-Pencil")
+      .executeAsync(
+        function (done) {
+          var rectangleTool = Tools.list.Rectangle;
+          var rectToolElem = document.getElementById("toolID-Rectangle");
+          var evt = {
+            preventDefault: function () {},
+          };
+
+          rectToolElem.classList.remove("disabledTool");
+          rectToolElem.setAttribute("aria-disabled", "false");
+          Tools.shouldDisableTool = function () {
+            return false;
+          };
+          Tools.canUseTool = function () {
+            return true;
+          };
+
+          var changed = Tools.change("Rectangle");
+          rectangleTool.listeners.press(10, 10, evt);
+          rectangleTool.listeners.move(4015, 30, evt);
+          rectangleTool.listeners.release(4015, 30, evt);
+
+          setTimeout(function () {
+            done({
+              currentTool: Tools.curTool && Tools.curTool.name,
+              changeResult: changed,
+              rectPresent: !!document.querySelector("#drawingArea rect"),
+            });
+          }, 200);
+        },
+        function (result) {
+          browser.assert.equal(result.value.currentTool, "Rectangle");
+          browser.assert.equal(result.value.changeResult, true);
+          browser.assert.equal(result.value.rectPresent, true);
+        },
+      )
+      .perform(async function (done) {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        var storedBoard = await readStoredBoard(
+          dataPath,
+          "zoom-threshold-test",
+        );
+        browser.assert.equal(Object.keys(storedBoard).length, 0);
+        done();
+      })
       .execute(
         function () {
+          Tools.shouldDisableTool = function (toolName) {
+            return (
+              MessageCommon.isDrawTool(toolName) &&
+              !MessageCommon.isDrawToolAllowedAtScale(Tools.scale || 1)
+            );
+          };
+          Tools.canUseTool = function (toolName) {
+            return (
+              Tools.shouldDisplayTool(toolName) &&
+              !Tools.shouldDisableTool(toolName)
+            );
+          };
           return {
             currentTool: Tools.curTool && Tools.curTool.name,
             changeResult: Tools.change("Pencil"),
@@ -206,7 +267,7 @@ module.exports = {
         },
         [],
         function (result) {
-          browser.assert.equal(result.value.currentTool, "Hand");
+          browser.assert.equal(result.value.currentTool, "Rectangle");
           browser.assert.equal(result.value.changeResult, false);
         },
       )


### PR DESCRIPTION
## Summary
Add a shared giant-shape policy used by both the client and server.

This change disables drawing tools when zoom is `<= 0.4`, rejects oversized shapes during message normalization, and blocks board mutations that would make an existing item oversized through pencil growth or transforms.

## Why
The board previously allowed creating or evolving shapes into very large geometry. That made the zoom threshold a client-only concern and left the server able to persist oversized shapes.

## What changed
- added shared geometry helpers in `client-data/js/message_common.js`
- disabled draw tools in the toolbar and guarded tool activation/send paths on the client
- enforced stateless server-side giant-shape rejection in `server/message_validation.js`
- enforced stateful board-side rejection for pencil child growth, transform updates, copies, and atomic hand batches in `server/boardData.js`
- stopped rebroadcasting board messages that fail board-level acceptance
- added Node and Nightwatch coverage for the shared geometry policy and zoom-threshold UX

## User impact
Users can no longer start drawing while zoomed too far out, and oversized shapes are rejected consistently whether they come from the local client, another client, persisted board history, or transform operations.

## Root cause
Shape size enforcement was not centralized. The client had no shared “too large” rule with the server, and stateful growth paths like pencil children and transforms were not revalidated after mutation.

## Validation
- `node --test test-node/*.test.js`
- `npm run prettier-check`
- `./node_modules/.bin/nightwatch tests/interaction.test.js --testcase "Test Draw Tools Disable At Giant Shape Zoom Threshold"`
