### PR TITLE
[codex] Add board page CSP header

### DIFF
--- a/server/security_headers.mjs
+++ b/server/security_headers.mjs
@@ -1,0 +1,2 @@
+export const CONTENT_SECURITY_POLICY =
+  "default-src 'self'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; frame-src 'self' https://challenges.cloudflare.com;";

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -34,6 +34,7 @@ import * as jwtBoardName from "./jwtBoardnameAuth.mjs";
 import observability from "./observability.mjs";
 import { buildRandomBoardName } from "./pronounceable_name.mjs";
 import { parseRequestUrl, validateRequestUrl } from "./request_url.mjs";
+import { CONTENT_SECURITY_POLICY } from "./security_headers.mjs";
 import { getRequestClientIp } from "./socket_policy.mjs";
 import * as sockets from "./sockets.mjs";
 import {
@@ -64,9 +65,6 @@ const { createRequestId, logger, metrics, tracing } = observability;
  *   boardTemplate: templating.BoardTemplate,
  *   indexTemplate: templating.Template,
  * }} ServerRuntime */
-
-const CSP =
-  "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:";
 
 const STATIC_RESOURCE_EXTENSIONS = [
   ".js",
@@ -112,7 +110,7 @@ function createServerRuntime(config) {
     maxAge: 0,
     /** @param {HttpResponse} res */
     setHeaders: (res, /** @type {string} */ filePath) => {
-      res.setHeader("Content-Security-Policy", CSP);
+      res.setHeader("Content-Security-Policy", CONTENT_SECURITY_POLICY);
       const cacheValue = staticFileCacheControl(config, filePath || "");
       if (cacheValue !== undefined) {
         res.setHeader("Cache-Control", cacheValue);
@@ -1204,7 +1202,7 @@ async function handleBoardSvgRoute(
     request.headers["accept-encoding"],
     {
       "Content-Type": "image/svg+xml",
-      "Content-Security-Policy": CSP,
+      "Content-Security-Policy": CONTENT_SECURITY_POLICY,
       "Cache-Control": boardSvgCacheControl(runtime.config),
     },
   );
@@ -1423,7 +1421,7 @@ async function respondWithBoardPreview(
   }
   const compressedResponse = startCompressedResponse(response, acceptEncoding, {
     "Content-Type": "image/svg+xml",
-    "Content-Security-Policy": CSP,
+    "Content-Security-Policy": CONTENT_SECURITY_POLICY,
     "Cache-Control": boardSvgCacheControl(runtime.config),
   });
   annotateResponseCompression(requestContext, compressedResponse.encoding);

--- a/server/templating.mjs
+++ b/server/templating.mjs
@@ -7,6 +7,7 @@ import { TOOL_BY_ID, TOOLBAR_TOOLS } from "../client-data/tools/index.js";
 import { createClientConfiguration } from "./client_configuration.mjs";
 import { startCompressedResponse } from "./http_compression.mjs";
 import { parseRequestUrl } from "./request_url.mjs";
+import { CONTENT_SECURITY_POLICY } from "./security_headers.mjs";
 
 /** @typedef {{[name: string]: string}} TranslationDictionary */
 /** @typedef {{[language: string]: TranslationDictionary}} TranslationMap */
@@ -188,6 +189,7 @@ const startHtmlResponse =
         ? {}
         : { "Content-Length": contentLength }),
       "Content-Type": "text/html",
+      "Content-Security-Policy": CONTENT_SECURITY_POLICY,
       "Cache-Control": cacheControlValue,
       ...(typeof parameters.etag === "string" ? { ETag: parameters.etag } : {}),
       ...(!parsedUrl.searchParams.get("lang")

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -373,6 +373,10 @@ test("board pages set an httpOnly user secret cookie when missing", async () => 
       const setCookie = getSingleSetCookie(response.headers);
 
       assert.equal(response.statusCode, 200);
+      assert.equal(
+        response.headers["content-security-policy"],
+        "default-src 'self'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; frame-src 'self' https://challenges.cloudflare.com;",
+      );
       assert.match(
         setCookie,
         /^wbo-user-secret-v1=[0-9a-f]{32}; Max-Age=31536000; Path=\/; HttpOnly; SameSite=Lax$/,


### PR DESCRIPTION
## Summary
Add `Content-Security-Policy` to templated board HTML responses and centralize the policy string so board HTML, static assets, and SVG responses use the same header source.

## Root Cause
CSP was defined in `server/server.mjs`, but board HTML responses are built through `server/templating.mjs:startHtmlResponse`. That path set `Content-Type`, `Cache-Control`, `ETag`, and `Vary`, but never attached `Content-Security-Policy`, so `/boards/<name>` shipped without CSP while static and SVG routes still had it.

## What Changed
- added `server/security_headers.mjs` as the shared CSP source
- switched `server/server.mjs` static, SVG, and preview responses to use the shared CSP constant
- added CSP to templated HTML responses in `server/templating.mjs`
- added a route test asserting the board page returns the CSP header

## Impact
Board HTML responses now send CSP instead of only static assets and SVG endpoints doing so.

## Validation
- `node --test test-node/server_routes.test.js`
- `node --test test-node/server_routes.test.js test-node/turnstile.test.js`
- `npm test` ❌
  - `node --test test-node/*.test.js` passed
  - `playwright test` failed in 9 specs, so lint did not run

## Remaining Work
The current CSP is still too strict for the browser runtime.

Evidence:
- Turnstile needed explicit `script-src` and `frame-src` allowances for `https://challenges.cloudflare.com`
- after that adjustment, Playwright still failed broadly across auth, collaboration, reconnect, and Turnstile flows
- the failure pattern suggests additional board-page runtime requirements are blocked, likely inline boot scripts and/or other browser-side policy needs

Follow-up needed:
- inspect the failing Playwright cases against browser CSP violations
- identify the minimum additional CSP allowances needed for the board page to boot correctly
- rerun the full `npm test` gate after narrowing the policy
