### PR TITLE
Hand tool: prefer native touch panning, ignore multi-touch pointer events, and add tests

### DIFF
--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -2545,6 +2545,20 @@ function createMountedTool(toolModule, toolState, toolName) {
       if (isTouchEvent) {
         const touchEvent = /** @type {TouchEvent} */ (evt);
         if (touchEvent.changedTouches.length !== 1) return true;
+        if (
+          (touchEvent.type === "touchstart" ||
+            touchEvent.type === "touchmove") &&
+          touchEvent.touches.length !== 1
+        ) {
+          return true;
+        }
+        if (
+          (touchEvent.type === "touchend" ||
+            touchEvent.type === "touchcancel") &&
+          touchEvent.touches.length !== 0
+        ) {
+          return true;
+        }
         const touch = touchEvent.changedTouches[0];
         if (!touch) return true;
         return listener(

--- a/client-data/tools/hand/index.js
+++ b/client-data/tools/hand/index.js
@@ -804,7 +804,7 @@ function getPointerClientCoord(evt, axis) {
 function startHand(state, _x, _y, evt, isTouchEvent) {
   void _x;
   void _y;
-  void isTouchEvent;
+  if (isTouchEvent) return;
   if (evt.cancelable) evt.preventDefault();
   state.Tools.viewport.beginPan(
     getPointerClientCoord(evt, "clientX"),
@@ -823,7 +823,7 @@ function startHand(state, _x, _y, evt, isTouchEvent) {
 function moveHand(state, _x, _y, evt, isTouchEvent) {
   void _x;
   void _y;
-  void isTouchEvent;
+  if (isTouchEvent) return;
   if (state.selected && !("w" in state.selected)) {
     if (evt.cancelable) evt.preventDefault();
     state.Tools.viewport.movePan(
@@ -841,6 +841,34 @@ function endHand(state) {
 /** @param {HandState} state */
 function isSelectorActive(state) {
   return !!(state.secondary && state.secondary.active);
+}
+
+/**
+ * @param {HandState} state
+ * @returns {void}
+ */
+function syncHandTouchAction(state) {
+  const touchAction = isSelectorActive(state) ? "" : "pan-x pan-y";
+  if (state.Tools.board) state.Tools.board.style.touchAction = touchAction;
+  if (state.Tools.svg) state.Tools.svg.style.touchAction = touchAction;
+}
+
+/**
+ * @param {HandState} state
+ * @param {{resetTouchAction: boolean}} options
+ * @returns {void}
+ */
+function resetHandUiState(state, options) {
+  if (options.resetTouchAction) {
+    if (state.Tools.board) state.Tools.board.style.touchAction = "";
+    if (state.Tools.svg) state.Tools.svg.style.touchAction = "";
+  } else {
+    syncHandTouchAction(state);
+  }
+  state.selected = null;
+  hideSelectionUI(state);
+  window.removeEventListener("keydown", state.boundDeleteShortcut);
+  window.removeEventListener("keydown", state.boundDuplicateShortcut);
 }
 
 /**
@@ -876,8 +904,10 @@ export function move(state, x, y, evt, isTouchEvent) {
  */
 export function release(state, x, y, evt, isTouchEvent) {
   if (!isSelectorActive(state)) {
-    moveHand(state, x, y, evt, isTouchEvent);
-    endHand(state);
+    if (!isTouchEvent) {
+      moveHand(state, x, y, evt, false);
+      endHand(state);
+    }
   } else moveSelector(state, x, y, evt, true);
   if (isSelectorActive(state)) releaseSelector(state);
   state.selected = null;
@@ -907,7 +937,7 @@ function duplicateShortcut(state, e) {
 
 /** @param {HandState} state */
 function switchTool(state) {
-  onquit(state);
+  resetHandUiState(state, { resetTouchAction: false });
   if (isSelectorActive(state)) {
     window.addEventListener("keydown", state.boundDeleteShortcut);
     window.addEventListener("keydown", state.boundDuplicateShortcut);
@@ -924,10 +954,12 @@ export async function boot(ctx) {
 
 /** @param {HandState} state */
 export function onquit(state) {
-  state.selected = null;
-  hideSelectionUI(state);
-  window.removeEventListener("keydown", state.boundDeleteShortcut);
-  window.removeEventListener("keydown", state.boundDuplicateShortcut);
+  resetHandUiState(state, { resetTouchAction: true });
+}
+
+/** @param {HandState} state */
+export function onstart(state) {
+  syncHandTouchAction(state);
 }
 
 /** @param {HandState} state */

--- a/test-node/client_tool_replay.test.js
+++ b/test-node/client_tool_replay.test.js
@@ -1598,6 +1598,77 @@ test("Hand selector keeps the original element selected after duplicate", async 
   });
 });
 
+test("Hand tool enables native touch panning when selector mode is off", async () => {
+  const harness = createHarness();
+  const handTool = await harness.loadTool("hand");
+
+  assert.equal(globalAny.Tools.board.style.touchAction, undefined);
+  assert.equal(globalAny.Tools.svg.style.touchAction, undefined);
+
+  handTool.onstart?.(null);
+  assert.equal(globalAny.Tools.board.style.touchAction, "pan-x pan-y");
+  assert.equal(globalAny.Tools.svg.style.touchAction, "pan-x pan-y");
+
+  handTool.secondary.active = true;
+  handTool.secondary.switch();
+  assert.equal(globalAny.Tools.board.style.touchAction, "");
+  assert.equal(globalAny.Tools.svg.style.touchAction, "");
+
+  handTool.secondary.active = false;
+  handTool.secondary.switch();
+  assert.equal(globalAny.Tools.board.style.touchAction, "pan-x pan-y");
+  assert.equal(globalAny.Tools.svg.style.touchAction, "pan-x pan-y");
+});
+
+test("Hand tool touch gestures do not run synthetic drag panning", async () => {
+  const harness = createHarness();
+  const handTool = await harness.loadTool("hand");
+  let prevented = 0;
+
+  handTool.onstart?.(null);
+  handTool.listeners.press(
+    0,
+    0,
+    {
+      touches: [{ clientX: 100, clientY: 100 }],
+      changedTouches: [{ clientX: 100, clientY: 100 }],
+      cancelable: true,
+      preventDefault: () => {
+        prevented += 1;
+      },
+    },
+    true,
+  );
+  handTool.listeners.move(
+    0,
+    0,
+    {
+      touches: [{ clientX: 120, clientY: 120 }],
+      changedTouches: [{ clientX: 120, clientY: 120 }],
+      cancelable: true,
+      preventDefault: () => {
+        prevented += 1;
+      },
+    },
+    true,
+  );
+  handTool.listeners.release(
+    0,
+    0,
+    {
+      touches: [],
+      changedTouches: [{ clientX: 120, clientY: 120 }],
+      cancelable: true,
+      preventDefault: () => {
+        prevented += 1;
+      },
+    },
+    true,
+  );
+
+  assert.equal(prevented, 0);
+});
+
 test("Eraser replay removes only the targeted stable id", async () => {
   const harness = createHarness();
   const eraserTool = await harness.loadTool("eraser");


### PR DESCRIPTION
### Motivation
- Prevent synthetic drag panning during touch interactions and ensure multi-touch gestures don't trigger single-touch tool behavior.
- Restore correct touch-action styling when switching selector mode so the browser can handle native panning when appropriate.

### Description
- Strengthen touch-event filtering in `createMountedTool` to ignore multi-touch `touchstart`, `touchmove`, `touchend`, and `touchcancel` sequences so only valid single-touch events reach tools (`client-data/js/board.js`).
- Update the Hand tool (`client-data/tools/hand/index.js`) to skip synthesized pan behavior for touch events and to manage `touch-action` CSS on the board and SVG elements via `syncHandTouchAction`, `resetHandUiState`, `onstart`, and updated `onquit` logic.
- Ensure selector mode toggling updates the `touch-action` appropriately so native panning is enabled when selector mode is off and disabled when selector mode is on.
- Add tests to `test-node/client_tool_replay.test.js` that verify `touch-action` is set correctly and that touch gestures do not trigger synthetic drag panning.

### Testing
- Added unit tests `Hand tool enables native touch panning when selector mode is off` and `Hand tool touch gestures do not run synthetic drag panning` in `test-node/client_tool_replay.test.js` and ran the test suite; the new tests passed.
- Ran existing client tool replay tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb990e6208331a22e7854a77c0dd5)