### PR TITLE
[codex] Fix hand touch panning policy

### DIFF
--- a/client-data/js/board.js
+++ b/client-data/js/board.js
@@ -229,6 +229,7 @@ export async function attachBoardDom(document) {
     document.body.clientHeight,
   );
   normalizeServerRenderedElements();
+  Tools.syncActiveToolInputPolicy();
 }
 
 Tools.i18n = (function i18n() {
@@ -1146,6 +1147,7 @@ Tools.beginAuthoritativeResync = function beginAuthoritativeResync() {
   Object.values(Tools.list || {}).forEach((tool) => {
     if (tool) tool.onSocketDisconnect();
   });
+  Tools.syncActiveToolInputPolicy();
   Tools.syncWriteStatusIndicator();
 };
 
@@ -2492,6 +2494,7 @@ function createMountedTool(toolModule, toolState, toolName) {
   const onMutationRejected = toolModule.onMutationRejected;
   const onSizeChange = toolModule.onSizeChange;
   const touchListenerOptions = toolModule.touchListenerOptions;
+  const getTouchPolicy = toolModule.getTouchPolicy;
   const toolStateObject =
     /** @type {{mouseCursor?: string, secondary?: import("../../types/app-runtime").ToolSecondaryMode | null} | null} */ (
       toolState && typeof toolState === "object" ? toolState : null
@@ -2552,6 +2555,10 @@ function createMountedTool(toolModule, toolState, toolName) {
     onSizeChange:
       typeof onSizeChange === "function"
         ? (size) => onSizeChange(toolState, size)
+        : undefined,
+    getTouchPolicy:
+      typeof getTouchPolicy === "function"
+        ? () => getTouchPolicy(toolState)
         : undefined,
     showMarker: toolModule.showMarker,
     requiresWritableBoard: toolModule.requiresWritableBoard,
@@ -2757,6 +2764,7 @@ function toggleSecondaryTool(newTool) {
   toggleToolButtonMode(newTool.name, props.name, props.icon);
   if (newTool.secondary.switch) newTool.secondary.switch();
   syncActiveToolState();
+  Tools.syncActiveToolInputPolicy();
 }
 
 /**
@@ -2810,6 +2818,12 @@ function syncActiveToolState() {
     currentTool.secondary && currentTool.secondary.active ? "true" : "false";
 }
 
+Tools.syncActiveToolInputPolicy = function syncActiveToolInputPolicy() {
+  Tools.viewport.setTouchPolicy(
+    Tools.curTool?.getTouchPolicy?.() || "app-gesture",
+  );
+};
+
 /** @param {string} toolName */
 Tools.change = (toolName) => {
   const newTool = Tools.list[toolName];
@@ -2827,6 +2841,7 @@ Tools.change = (toolName) => {
   }
 
   if (newTool.onstart) newTool.onstart(oldTool);
+  Tools.syncActiveToolInputPolicy();
   return true;
 };
 

--- a/client-data/js/board_viewport.js
+++ b/client-data/js/board_viewport.js
@@ -37,11 +37,14 @@ const BOARD_EXTENT_MARGIN = 20000;
  * }} ViewportState
  */
 
+/** @typedef {"app-gesture" | "native-pan"} ViewportTouchPolicy */
+
 /**
  * @typedef {{
  *   setScale(scale: number): number,
  *   getScale(): number,
  *   syncLayoutSize(): void,
+ *   setTouchPolicy(policy: ViewportTouchPolicy): void,
  *   ensureBoardExtentAtLeast(width: number, height: number): boolean,
  *   ensureBoardExtentForPoint(x: number, y: number): boolean,
  *   ensureBoardExtentForBounds(bounds: {maxX: number, maxY: number} | null | undefined): boolean,
@@ -250,6 +253,8 @@ export function createViewportController(Tools) {
   let lastViewportHashStateUpdate = Date.now();
   let installed = false;
   let hashObserversInstalled = false;
+  /** @type {ViewportTouchPolicy} */
+  let touchPolicy = "app-gesture";
   /** @type {{x: number, y: number, scrollLeft: number, scrollTop: number} | null} */
   let activePan = null;
   /** @type {{distance: number, scale: number} | null} */
@@ -295,6 +300,15 @@ export function createViewportController(Tools) {
   /**
    * @returns {void}
    */
+  function applyTouchPolicy() {
+    const touchAction = touchPolicy === "native-pan" ? "auto" : "";
+    if (Tools.board) Tools.board.style.touchAction = touchAction;
+    if (Tools.svg?.style) Tools.svg.style.touchAction = touchAction;
+  }
+
+  /**
+   * @returns {void}
+   */
   function syncLayoutSize() {
     if (!Tools.board || !Tools.svg) return;
     const size = getScaledBoardLayoutSize(
@@ -307,6 +321,7 @@ export function createViewportController(Tools) {
     Tools.board.style.width = `${size.width}px`;
     Tools.board.style.height = `${size.height}px`;
     Tools.board.dataset.viewportManaged = "true";
+    applyTouchPolicy();
   }
 
   /**
@@ -542,6 +557,10 @@ export function createViewportController(Tools) {
     setScale,
     getScale: () => Tools.scale,
     syncLayoutSize,
+    setTouchPolicy(policy) {
+      touchPolicy = policy === "native-pan" ? "native-pan" : "app-gesture";
+      applyTouchPolicy();
+    },
     ensureBoardExtentAtLeast,
     ensureBoardExtentForPoint,
     ensureBoardExtentForBounds,

--- a/client-data/tools/hand/index.js
+++ b/client-data/tools/hand/index.js
@@ -1146,25 +1146,8 @@ function isSelectorActive(state) {
  * @param {HandState} state
  * @returns {void}
  */
-function syncHandTouchAction(state) {
-  const touchAction = isSelectorActive(state) ? "" : "auto";
-  if (state.Tools.board) state.Tools.board.style.touchAction = touchAction;
-  if (state.Tools.svg) state.Tools.svg.style.touchAction = touchAction;
-}
-
-/**
- * @param {HandState} state
- * @param {{resetTouchAction: boolean}} options
- * @returns {void}
- */
-function resetHandUiState(state, options) {
+function resetHandUiState(state) {
   state.selectionRunId += 1;
-  if (options.resetTouchAction) {
-    if (state.Tools.board) state.Tools.board.style.touchAction = "";
-    if (state.Tools.svg) state.Tools.svg.style.touchAction = "";
-  } else {
-    syncHandTouchAction(state);
-  }
   state.selected = null;
   hideSelectionUI(state);
   window.removeEventListener("keydown", state.boundDeleteShortcut);
@@ -1238,7 +1221,7 @@ function duplicateShortcut(state, e) {
 
 /** @param {HandState} state */
 function switchTool(state) {
-  resetHandUiState(state, { resetTouchAction: false });
+  resetHandUiState(state);
   if (isSelectorActive(state)) {
     window.addEventListener("keydown", state.boundDeleteShortcut);
     window.addEventListener("keydown", state.boundDuplicateShortcut);
@@ -1253,12 +1236,12 @@ export async function boot(ctx) {
 
 /** @param {HandState} state */
 export function onquit(state) {
-  resetHandUiState(state, { resetTouchAction: true });
+  resetHandUiState(state);
 }
 
 /** @param {HandState} state */
-export function onstart(state) {
-  syncHandTouchAction(state);
+export function getTouchPolicy(state) {
+  return isSelectorActive(state) ? "app-gesture" : "native-pan";
 }
 
 /** @param {HandState} state */

--- a/playwright/tests/interaction.spec.ts
+++ b/playwright/tests/interaction.spec.ts
@@ -74,6 +74,17 @@ async function expectViewportRestoreAfterConnect(
   });
 }
 
+async function readBoardTouchAction(page: Page) {
+  return page.evaluate(() => {
+    const board = document.getElementById("board");
+    const svg = document.getElementById("canvas");
+    return {
+      board: board ? getComputedStyle(board).touchAction : "",
+      svg: svg ? getComputedStyle(svg).touchAction : "",
+    };
+  });
+}
+
 test.describe("single-page interactions", () => {
   test("selector moves existing rectangle", async ({
     boardPage,
@@ -287,6 +298,50 @@ test.describe("single-page interactions", () => {
       .toMatchObject({
         left: 200,
         top: 150,
+      });
+  });
+
+  test("hand touch panning policy survives authoritative resync", async ({
+    boardPage,
+    page,
+  }) => {
+    await boardPage.gotoBoard("hand-touch-policy-resync-test");
+    await expect(boardPage.tool("hand")).toBeVisible();
+    await boardPage.expectCurrentTool("hand");
+
+    await expect
+      .poll(() => readBoardTouchAction(page))
+      .toMatchObject({
+        board: "auto",
+        svg: "auto",
+      });
+
+    await page.evaluate(() => {
+      window.Tools.beginAuthoritativeResync();
+    });
+
+    await boardPage.expectCurrentTool("hand");
+    await expect
+      .poll(() => readBoardTouchAction(page))
+      .toMatchObject({
+        board: "auto",
+        svg: "auto",
+      });
+
+    await boardPage.tool("hand").click();
+    await expect
+      .poll(() => readBoardTouchAction(page))
+      .toMatchObject({
+        board: "none",
+        svg: "none",
+      });
+
+    await boardPage.tool("hand").click();
+    await expect
+      .poll(() => readBoardTouchAction(page))
+      .toMatchObject({
+        board: "auto",
+        svg: "auto",
       });
   });
 

--- a/test-node/board_viewport.test.js
+++ b/test-node/board_viewport.test.js
@@ -123,6 +123,7 @@ test("viewport owns svg extent growth and layout sync", async () => {
     assert.deepEqual(tools.board.style, {
       width: "500px",
       height: "500px",
+      touchAction: "",
     });
     assert.equal(tools.board.dataset.viewportManaged, "true");
 
@@ -169,6 +170,7 @@ test("viewport expands to the full board at minimum zoom", async () => {
     assert.deepEqual(tools.board.style, {
       width: "100px",
       height: "100px",
+      touchAction: "",
     });
   } finally {
     globalAny.window = previousWindow;

--- a/test-node/client_tool_replay.test.js
+++ b/test-node/client_tool_replay.test.js
@@ -543,6 +543,10 @@ function createHarness() {
             ? (/** @type {number} */ size) =>
                 moduleNamespace.onSizeChange(toolState, size)
             : undefined,
+        getTouchPolicy:
+          typeof moduleNamespace.getTouchPolicy === "function"
+            ? () => moduleNamespace.getTouchPolicy(toolState)
+            : undefined,
       });
       if (!tool.listeners) {
         tool.listeners = {
@@ -1884,7 +1888,7 @@ test("Hand box selection does not fall back to target bbox reads without Interse
   }
 });
 
-test("Hand tool enables native touch scrolling when selector mode is off", async () => {
+test("Hand tool declares native touch scrolling when selector mode is off", async () => {
   const harness = createHarness();
   const handTool = await harness.loadTool("hand");
 
@@ -1892,18 +1896,21 @@ test("Hand tool enables native touch scrolling when selector mode is off", async
   assert.equal(globalAny.Tools.svg.style.touchAction, undefined);
 
   handTool.onstart?.(null);
-  assert.equal(globalAny.Tools.board.style.touchAction, "auto");
-  assert.equal(globalAny.Tools.svg.style.touchAction, "auto");
+  assert.equal(handTool.getTouchPolicy?.(), "native-pan");
+  assert.equal(globalAny.Tools.board.style.touchAction, undefined);
+  assert.equal(globalAny.Tools.svg.style.touchAction, undefined);
 
   handTool.secondary.active = true;
   handTool.secondary.switch();
-  assert.equal(globalAny.Tools.board.style.touchAction, "");
-  assert.equal(globalAny.Tools.svg.style.touchAction, "");
+  assert.equal(handTool.getTouchPolicy?.(), "app-gesture");
+  assert.equal(globalAny.Tools.board.style.touchAction, undefined);
+  assert.equal(globalAny.Tools.svg.style.touchAction, undefined);
 
   handTool.secondary.active = false;
   handTool.secondary.switch();
-  assert.equal(globalAny.Tools.board.style.touchAction, "auto");
-  assert.equal(globalAny.Tools.svg.style.touchAction, "auto");
+  assert.equal(handTool.getTouchPolicy?.(), "native-pan");
+  assert.equal(globalAny.Tools.board.style.touchAction, undefined);
+  assert.equal(globalAny.Tools.svg.style.touchAction, undefined);
 });
 
 test("Hand tool touch gestures do not run synthetic drag panning", async () => {

--- a/types/app-runtime.d.ts
+++ b/types/app-runtime.d.ts
@@ -272,6 +272,8 @@ export type ToolSecondaryMode = {
   switch?: () => void;
 };
 
+export type ToolTouchPolicy = "app-gesture" | "native-pan";
+
 export type MountedAppTool = {
   name: string;
   shortcut?: string;
@@ -296,6 +298,7 @@ export type MountedAppTool = {
   helpText?: string;
   secondary?: ToolSecondaryMode | null;
   onSizeChange?: (size: number) => void;
+  getTouchPolicy?: () => ToolTouchPolicy;
   showMarker?: boolean;
   requiresWritableBoard?: boolean;
   touchListenerOptions?: ToolListenerOptions;
@@ -583,12 +586,14 @@ export type ToolModule<T = unknown> = {
     reason?: string,
   ) => void;
   onSizeChange?: (state: T, size: number) => void;
+  getTouchPolicy?: (state: T) => ToolTouchPolicy;
 };
 
 export type ViewportController = {
   setScale: (scale: number) => number;
   getScale: () => number;
   syncLayoutSize: () => void;
+  setTouchPolicy: (policy: ToolTouchPolicy) => void;
   ensureBoardExtentAtLeast: (width: number, height: number) => boolean;
   ensureBoardExtentForPoint: (x: number, y: number) => boolean;
   ensureBoardExtentForBounds: (
@@ -749,6 +754,7 @@ export type AppToolsState = {
   activateTool: (toolName: string) => Promise<boolean>;
   addToolListeners: (tool: MountedAppTool) => void;
   removeToolListeners: (tool: MountedAppTool) => void;
+  syncActiveToolInputPolicy: () => void;
   /** Takes ownership of message. Callers must not mutate it after sending. */
   drawAndSend: (message: LiveBoardMessage) => boolean | undefined;
   /** Takes ownership of message. Callers must not mutate it after sending. */


### PR DESCRIPTION
## Summary
- fix mobile hand-tool panning after authoritative resync/socket cleanup
- move board/SVG `touch-action` ownership into the viewport controller
- make tools declare the input policy they need, with hand choosing native panning outside selector mode

## Root Cause
The hand tool directly wrote global board/SVG `touch-action` styles. During authoritative resync, `onSocketDisconnect()` reused hand cleanup, clearing those styles while the active tool still remained hand. The board then fell back to CSS `touch-action: none`, so native touch panning stopped until the hand tool was reselected.

## Validation
- Red: `npx playwright test playwright/tests/interaction.spec.ts --grep "hand touch panning policy"` failed before the fix with computed `touch-action: none` after resync.
- Green: `npx playwright test playwright/tests/interaction.spec.ts --grep "hand touch panning policy"`
- `npm run typecheck`
- `npx playwright test playwright/tests/interaction.spec.ts --grep "hand"`
- `node --test test-node/board_viewport.test.js test-node/client_tool_replay.test.js`
- `npm test`