### PR TITLE
Fix reverse-proxy base path handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Runtime logging, metrics, and tracing start from
 [observability/index.mjs](./server/observability/index.mjs), with setup details
 in [logging.mjs](./server/observability/logging.mjs) and metric utilities in
 [metric_helpers.mjs](./server/observability/metric_helpers.mjs).
+`WBO_BASE_PATH` public path handling lives with request URL parsing.
 
 Every HTTP request passes through [dispatch.mjs](./server/http/dispatch.mjs),
 where URL validation, route matching, route-level access checks, request

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ to make whitebophir only listen on the loopback device. This is useful if you wa
 
 By default, WBO launches its own web server and serves all of its content at the root of the server (on `/`).
 If you want to make the server accessible with a different path like `https://your.domain.com/wbo/` you have to setup a reverse proxy.
+Set `WBO_BASE_PATH=/wbo` so generated links, redirects, and canonical URLs point at the external subfolder.
 See instructions on our Wiki about [how to setup a reverse proxy for WBO](https://github.com/lovasoa/whitebophir/wiki/Setup-behind-Reverse-Proxies).
 
 ## Translations
@@ -177,6 +178,7 @@ You can see a list of these variables in [`configuration.mjs`](./server/configur
 Some important environment variables are :
 
 - `WBO_HISTORY_DIR` : configures the directory where the boards are saved. Defaults to `./server-data/`.
+- `WBO_BASE_PATH` : optional external URL path prefix, such as `/wbo`, for deployments mounted under a reverse-proxy subfolder.
 - `WBO_HTML_HEAD_SNIPPET_PATH` : optional path to an HTML snippet inserted raw before `</head>` on rendered HTML pages. This is useful for adding user analytics scripts or similar trusted snippets. The file is read once at server startup; relative paths resolve from the server working directory.
 - `WBO_MAX_EMIT_COUNT` : the general socket write limit profile. Use compact entries such as `*:250/5s anonymous:125/5s`. Increase this if you want smoother drawings, at the expense of making denial-of-service bursts cheaper for clients. The default is `*:250/5s`.
 - `WBO_MAX_CONSTRUCTIVE_ACTIONS_PER_IP` : the constructive per-IP write limit profile. Use compact entries such as `*:40/10s anonymous:20/10s`.

--- a/client-data/index.html
+++ b/client-data/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>WBO — {{translations.collaborative_whiteboard}}</title>
+    <base href="{{baseHref}}" />
     <link rel="stylesheet" href="index.css" />
     <meta name="description" content="{{translations.tagline}}" />
     <meta
@@ -114,5 +115,5 @@
     </main>
   </body>
 
-  <script type="module" src="../js/index.js"></script>
+  <script type="module" src="js/index.js"></script>
 </html>

--- a/client-data/js/index.js
+++ b/client-data/js/index.js
@@ -36,7 +36,7 @@ function showRecentBoards() {
     (name) => {
       const listItem = document.createElement("li");
       const link = document.createElement("a");
-      link.setAttribute("href", `/boards/${encodeURIComponent(name)}`);
+      link.setAttribute("href", `boards/${encodeURIComponent(name)}`);
       link.textContent = name;
       listItem.appendChild(link);
       list.appendChild(listItem);

--- a/playwright/helpers/testServer.ts
+++ b/playwright/helpers/testServer.ts
@@ -164,13 +164,17 @@ export async function startTestServer(
   const stopCollectingStderr = collectChildStderr(child, stderr);
 
   try {
-    const serverUrl = await waitForServerStarted(
+    const internalServerUrl = await waitForServerStarted(
       child,
       () => stdoutBuffer,
       (chunk) => {
         stdoutBuffer += chunk;
       },
     );
+    const serverUrl = new URL(
+      env.WBO_BASE_PATH || "",
+      `${internalServerUrl}/`,
+    ).href.replace(/\/$/, "");
 
     return {
       child,

--- a/playwright/tests/drawing.spec.ts
+++ b/playwright/tests/drawing.spec.ts
@@ -30,6 +30,10 @@ const edgeTextTest = test.extend({
   },
 });
 
+const basePathTest = test.extend({
+  serverOptions: { env: { WBO_BASE_PATH: "/custom/base/path" } },
+});
+
 const CREATE_MUTATION = 1;
 const DELETE_MUTATION = 3;
 
@@ -53,6 +57,16 @@ async function drawScreenRectangle(
 }
 
 test.describe("drawing and persistence", () => {
+  basePathTest(
+    "draws under a custom base path",
+    async ({ boardPage, page }) => {
+      await boardPage.gotoBoard("base-path-drawing");
+      await expect(page).toHaveURL(/\/custom\/base\/path\/boards\//);
+      await drawMarkerRectangle(boardPage, page);
+      await boardPage.waitForBufferedWritesDrained();
+    },
+  );
+
   test("pencil persists and renders in preview", async ({
     boardPage,
     page,

--- a/playwright/tests/drawing.spec.ts
+++ b/playwright/tests/drawing.spec.ts
@@ -30,10 +30,6 @@ const edgeTextTest = test.extend({
   },
 });
 
-const basePathTest = test.extend({
-  serverOptions: { env: { WBO_BASE_PATH: "/custom/base/path" } },
-});
-
 const CREATE_MUTATION = 1;
 const DELETE_MUTATION = 3;
 
@@ -57,16 +53,6 @@ async function drawScreenRectangle(
 }
 
 test.describe("drawing and persistence", () => {
-  basePathTest(
-    "draws under a custom base path",
-    async ({ boardPage, page }) => {
-      await boardPage.gotoBoard("base-path-drawing");
-      await expect(page).toHaveURL(/\/custom\/base\/path\/boards\//);
-      await drawMarkerRectangle(boardPage, page);
-      await boardPage.waitForBufferedWritesDrained();
-    },
-  );
-
   test("pencil persists and renders in preview", async ({
     boardPage,
     page,

--- a/server/configuration.mjs
+++ b/server/configuration.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import {
+  parseBasePathEnv,
   parseCommaSeparatedEnv,
   parseDisabledFlagEnv,
   parseEnumEnv,
@@ -43,6 +44,9 @@ export const LOG_LEVEL = parseEnumEnv("LOG_LEVEL", LOG_LEVELS, "info");
 
 /** Static web root used to serve the client application files. */
 export const WEBROOT = parseStringEnv("WBO_WEBROOT", DEFAULT_WEBROOT);
+
+/** External URL path prefix used when WBO is mounted behind a reverse proxy. */
+export const BASE_PATH = parseBasePathEnv("WBO_BASE_PATH");
 
 /** Optional HTML snippet inserted before `</head>` in rendered HTML pages. */
 export const HTML_HEAD_SNIPPET_PATH = parseStringEnv(

--- a/server/configuration/helpers.mjs
+++ b/server/configuration/helpers.mjs
@@ -28,6 +28,24 @@ export function parseStringEnv(name, defaultValue, env = process.env) {
 /**
  * @param {string} name
  * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string}
+ */
+export function parseBasePathEnv(name, env = process.env) {
+  const value = parseStringEnv(name, "", env).trim();
+  if (value === "") return "";
+  if (!value.startsWith("/") || value.startsWith("//")) {
+    throw new Error(`Invalid ${name}: must be a URL path`);
+  }
+  const parsed = new URL(value, "http://wbo");
+  if (parsed.origin !== "http://wbo" || parsed.search || parsed.hash) {
+    throw new Error(`Invalid ${name}: must be a URL path`);
+  }
+  return parsed.pathname.replace(/\/+$/, "");
+}
+
+/**
+ * @param {string} name
+ * @param {NodeJS.ProcessEnv} [env]
  * @returns {string[]}
  */
 export function parseCommaSeparatedEnv(name, env = process.env) {

--- a/server/http/dispatch.mjs
+++ b/server/http/dispatch.mjs
@@ -6,7 +6,7 @@ import {
 } from "./observation.mjs";
 import * as jwtauth from "../auth/jwt.mjs";
 import observability from "../observability/index.mjs";
-import { validateRequestUrl } from "./request_url.mjs";
+import { stripConfiguredBasePath, validateRequestUrl } from "./request_url.mjs";
 
 const { logger } = observability;
 
@@ -106,7 +106,10 @@ function routeHttpRequests(routes) {
         if (parsedUrlResult.ok === false) {
           throw badRequest(parsedUrlResult.reason);
         }
-        const url = parsedUrlResult.value;
+        const url = stripConfiguredBasePath(
+          runtime.config,
+          parsedUrlResult.value,
+        );
         const { route, params } = matchHttpRoute(routes, url);
         observed.setRoute(route.routeName);
         if (route.access === "user") {

--- a/server/http/dispatch.mjs
+++ b/server/http/dispatch.mjs
@@ -6,7 +6,7 @@ import {
 } from "./observation.mjs";
 import * as jwtauth from "../auth/jwt.mjs";
 import observability from "../observability/index.mjs";
-import { stripConfiguredBasePath, validateRequestUrl } from "./request_url.mjs";
+import { publicPath, validateRequestUrl } from "./request_url.mjs";
 
 const { logger } = observability;
 
@@ -91,6 +91,21 @@ function matchHttpRoute(routes, url) {
 }
 
 /**
+ * Builds the configured public URL for route handlers from the internal route
+ * URL. Prefix-stripping proxies remove BASE_PATH before forwarding, but
+ * public-path consumers such as cookies still need the browser-visible path.
+ *
+ * @param {ServerRuntime["config"]} config
+ * @param {URL} url
+ * @returns {URL}
+ */
+function routePublicUrl(config, url) {
+  const publicUrl = new URL(url.href);
+  publicUrl.pathname = publicPath(config, url.pathname);
+  return publicUrl;
+}
+
+/**
  * Wraps route dispatch with request validation, request-scoped observation,
  * permission checks, error pages, and final metrics/logging.
  *
@@ -106,10 +121,8 @@ function routeHttpRequests(routes) {
         if (parsedUrlResult.ok === false) {
           throw badRequest(parsedUrlResult.reason);
         }
-        const url = stripConfiguredBasePath(
-          runtime.config,
-          parsedUrlResult.value,
-        );
+        const url = parsedUrlResult.value;
+        const publicUrl = routePublicUrl(runtime.config, url);
         const { route, params } = matchHttpRoute(routes, url);
         observed.setRoute(route.routeName);
         if (route.access === "user") {
@@ -122,6 +135,7 @@ function routeHttpRequests(routes) {
             runtime,
             observed,
             url,
+            publicUrl,
             params,
           }),
         );

--- a/server/http/request_url.mjs
+++ b/server/http/request_url.mjs
@@ -52,15 +52,3 @@ export function parseRequestUrl(requestUrl) {
 export function publicPath(config, pathname) {
   return `${config.BASE_PATH}${pathname}`;
 }
-
-/** @param {import("../../types/server-runtime.d.ts").ServerConfig} config @param {URL} url */
-export function stripConfiguredBasePath(config, url) {
-  const basePath = config.BASE_PATH;
-  if (
-    basePath &&
-    (url.pathname === basePath || url.pathname.startsWith(`${basePath}/`))
-  ) {
-    url.pathname = url.pathname.slice(basePath.length) || "/";
-  }
-  return url;
-}

--- a/server/http/request_url.mjs
+++ b/server/http/request_url.mjs
@@ -47,3 +47,20 @@ export function parseRequestUrl(requestUrl) {
   if (validated.ok) return validated.value;
   return new URL(`${REQUEST_URL_BASE}/`);
 }
+
+/** @param {import("../../types/server-runtime.d.ts").ServerConfig} config @param {string} pathname */
+export function publicPath(config, pathname) {
+  return `${config.BASE_PATH}${pathname}`;
+}
+
+/** @param {import("../../types/server-runtime.d.ts").ServerConfig} config @param {URL} url */
+export function stripConfiguredBasePath(config, url) {
+  const basePath = config.BASE_PATH;
+  if (
+    basePath &&
+    (url.pathname === basePath || url.pathname.startsWith(`${basePath}/`))
+  ) {
+    url.pathname = url.pathname.slice(basePath.length) || "/";
+  }
+  return url;
+}

--- a/server/http/templating.mjs
+++ b/server/http/templating.mjs
@@ -13,7 +13,7 @@ import { parseRequestUrl } from "./request_url.mjs";
 
 /** @typedef {{[name: string]: string}} TranslationDictionary */
 /** @typedef {{[language: string]: TranslationDictionary}} TranslationMap */
-/** @typedef {{baseUrl: string, languages: string[], language: string, translations: TranslationDictionary, configuration: object, moderator: boolean, htmlHeadSnippet: string, [name: string]: any}} TemplateParameters */
+/** @typedef {{baseUrl: string, baseHref: string, languages: string[], language: string, translations: TranslationDictionary, configuration: object, moderator: boolean, htmlHeadSnippet: string, [name: string]: any}} TemplateParameters */
 /** @typedef {import("http").IncomingMessage} TemplateRequest */
 /** @typedef {import("http").ServerResponse} TemplateResponse */
 /** @typedef {string | string[] | undefined} HeaderValue */
@@ -311,11 +311,14 @@ class Template extends StaticTemplate {
     }
     const translations = TRANSLATIONS[language] || {};
     const configuration = this.clientConfig;
-    const prefix = findPathPrefix(parsedUrl.pathname);
+    const prefix =
+      findPathPrefix(parsedUrl.pathname) ||
+      this.serverConfig.BASE_PATH.slice(1);
     const baseUrl = findBaseUrl(request) + (prefix ? `/${prefix}/` : "");
     const moderator = isModerator;
     return {
       baseUrl,
+      baseHref: new URL(".", baseUrl).href,
       languages,
       languageLinks: localizedLinks(languages, (linkLanguage) =>
         localizedUrl(baseUrl, linkLanguage),

--- a/server/routes/board_http_helpers.mjs
+++ b/server/routes/board_http_helpers.mjs
@@ -7,6 +7,7 @@ import {
 import { pinReplayBaseline } from "../board/registry.mjs";
 import { badRequest } from "../http/boundary_errors.mjs";
 import { requestScheme } from "../http/observation.mjs";
+import { publicPath } from "../http/request_url.mjs";
 import {
   appendSetCookieHeader,
   generateUserSecret,
@@ -149,12 +150,13 @@ function requireBoardDocumentNames(params, name = "board") {
 }
 
 /**
+ * @param {ServerConfig} config
  * @param {string} boardName
  * @param {string} [search]
  * @returns {string}
  */
-function boardDocumentLocation(boardName, search = "") {
-  return `/boards/${encodeURIComponent(boardName)}${search}`;
+function boardDocumentLocation(config, boardName, search = "") {
+  return `${publicPath(config, `/boards/${encodeURIComponent(boardName)}`)}${search}`;
 }
 
 /**

--- a/server/routes/board_page.mjs
+++ b/server/routes/board_page.mjs
@@ -87,7 +87,7 @@ async function serveBoardPage(ctx) {
     document.metadata.seq || 0,
     ctx.runtime.config,
   );
-  ensureBoardUserSecretCookie(ctx.request, ctx.response, ctx.url);
+  ensureBoardUserSecretCookie(ctx.request, ctx.response, ctx.publicUrl);
   await renderBoardDocument(ctx, pageRequest, document);
 }
 

--- a/server/routes/board_page.mjs
+++ b/server/routes/board_page.mjs
@@ -47,15 +47,16 @@ const { tracing } = observability;
  * @returns {void}
  */
 function redirectBoardQuery(ctx) {
+  const config = ctx.runtime.config;
   const boardName = requireBoardQueryName(ctx.url);
   annotateBoardRequest(ctx.observed, boardName);
   BoardPermissions.forBoard({
-    config: ctx.runtime.config,
+    config,
     boardName,
     userInfo: { token: ctx.url.searchParams.get("token") },
   }).requireOpen();
   ctx.response.writeHead(301, {
-    Location: boardDocumentLocation(boardName),
+    Location: boardDocumentLocation(config, boardName),
   });
   ctx.response.end();
 }
@@ -98,6 +99,7 @@ async function serveBoardPage(ctx) {
  * @returns {BoardPageRequest}
  */
 function resolveBoardPageRequest(ctx) {
+  const config = ctx.runtime.config;
   const { requestedBoardName, boardName } = requireBoardDocumentNames(
     ctx.params,
   );
@@ -105,13 +107,13 @@ function resolveBoardPageRequest(ctx) {
   if (requestedBoardName !== boardName) {
     return {
       kind: "redirect",
-      redirect: boardDocumentLocation(boardName, ctx.url.search),
+      redirect: boardDocumentLocation(config, boardName, ctx.url.search),
       boardName,
       cachedSeqs: [],
     };
   }
   const boardPermissions = BoardPermissions.forBoard({
-    config: ctx.runtime.config,
+    config,
     boardName,
     userInfo: { token: ctx.url.searchParams.get("token") },
   });

--- a/server/routes/static.mjs
+++ b/server/routes/static.mjs
@@ -34,7 +34,7 @@ function serveBoardStaticAsset(ctx) {
  * @returns {void}
  */
 function serveStaticFile(ctx, nextUrl) {
-  if (nextUrl !== undefined) ctx.request.url = nextUrl;
+  ctx.request.url = nextUrl || `${ctx.url.pathname}${ctx.url.search}`;
   ctx.runtime.fileserver(
     ctx.request,
     ctx.response,
@@ -49,7 +49,9 @@ function serveStaticFile(ctx, nextUrl) {
 async function redirectToRandomBoard(ctx) {
   const boardName = await allocateRandomBoardName(ctx.runtime.config);
   annotateBoardRequest(ctx.observed, boardName);
-  ctx.response.writeHead(307, { Location: boardDocumentLocation(boardName) });
+  ctx.response.writeHead(307, {
+    Location: boardDocumentLocation(ctx.runtime.config, boardName),
+  });
   ctx.response.end(boardName);
 }
 
@@ -73,7 +75,7 @@ function redirectToDefaultBoard(ctx) {
   if (defaultBoard !== "") {
     annotateBoardRequest(ctx.observed, defaultBoard);
     ctx.response.writeHead(302, {
-      Location: boardDocumentLocation(defaultBoard),
+      Location: boardDocumentLocation(ctx.runtime.config, defaultBoard),
     });
     ctx.response.end(defaultBoard);
     return;

--- a/server/socket/index.mjs
+++ b/server/socket/index.mjs
@@ -57,6 +57,7 @@ import {
   prepareConnectionReplay,
 } from "./replay.mjs";
 import { handleTurnstileTokenMessage } from "./turnstile.mjs";
+import { publicPath } from "../http/request_url.mjs";
 
 const { Server } = socketIO;
 const { logger, metrics, tracing } = observability;
@@ -359,7 +360,7 @@ function resolveClientIp(socket, boardName, config) {
  * @returns {Promise<import("socket.io").Server>}
  */
 async function startIO(app, config) {
-  io = new Server(app);
+  io = new Server(app, { path: publicPath(config, "/socket.io") });
   io.use(
     (
       /** @type {AppSocket} */ socket,

--- a/server/socket/index.mjs
+++ b/server/socket/index.mjs
@@ -57,7 +57,6 @@ import {
   prepareConnectionReplay,
 } from "./replay.mjs";
 import { handleTurnstileTokenMessage } from "./turnstile.mjs";
-import { publicPath } from "../http/request_url.mjs";
 
 const { Server } = socketIO;
 const { logger, metrics, tracing } = observability;
@@ -360,7 +359,7 @@ function resolveClientIp(socket, boardName, config) {
  * @returns {Promise<import("socket.io").Server>}
  */
 async function startIO(app, config) {
-  io = new Server(app, { path: publicPath(config, "/socket.io") });
+  io = new Server(app, { path: "/socket.io" });
   io.use(
     (
       /** @type {AppSocket} */ socket,

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -447,23 +447,31 @@ test("configured base path prefixes generated redirects and canonical urls", asy
     createServerConfig(dirs, { BASE_PATH: basePath, WEBROOT: CLIENT_WEBROOT }),
   );
   try {
-    const randomResponse = await request(app, `${basePath}/random`);
+    const randomResponse = await request(app, "/random");
     assert.match(
       randomResponse.headers.location || "",
       /^\/custom\/base\/path\/boards\//,
     );
     assert.equal(
-      (await request(app, `${basePath}/boards/Refugee%20Camp%202`)).headers
-        .location,
+      (await request(app, "/boards/Refugee%20Camp%202")).headers.location,
       `${basePath}/boards/refugee-camp-2`,
     );
     assert.match(
-      (await request(app, `${basePath}/`)).body,
+      (await request(app, "/")).body,
       /<base href="http:\/\/127\.0\.0\.1:\d+\/custom\/base\/path\/" \/>/,
     );
+    const boardResponse = await request(app, "/boards/base-path-board");
     assert.match(
-      (await request(app, `${basePath}/boards/base-path-board`)).body,
+      boardResponse.body,
       /\/custom\/base\/path\/boards\/base-path-board\?lang=en/,
+    );
+    assert.match(
+      getSingleSetCookie(boardResponse.headers),
+      /^wbo-user-secret-v1=[0-9a-f]{32}; Max-Age=31536000; Path=\/custom\/base\/path\/; HttpOnly; SameSite=Lax$/,
+    );
+    assert.equal(
+      (await request(app, "/socket.io/socket.io.js")).statusCode,
+      200,
     );
   } finally {
     await closeServer(app);

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -440,6 +440,36 @@ test("index route renders absolute canonical and hreflang urls", async () => {
   }
 });
 
+test("configured base path prefixes generated redirects and canonical urls", async () => {
+  const dirs = await createServerDirs();
+  const basePath = "/custom/base/path";
+  const app = await createTestServer(
+    createServerConfig(dirs, { BASE_PATH: basePath, WEBROOT: CLIENT_WEBROOT }),
+  );
+  try {
+    const randomResponse = await request(app, `${basePath}/random`);
+    assert.match(
+      randomResponse.headers.location || "",
+      /^\/custom\/base\/path\/boards\//,
+    );
+    assert.equal(
+      (await request(app, `${basePath}/boards/Refugee%20Camp%202`)).headers
+        .location,
+      `${basePath}/boards/refugee-camp-2`,
+    );
+    assert.match(
+      (await request(app, `${basePath}/`)).body,
+      /<base href="http:\/\/127\.0\.0\.1:\d+\/custom\/base\/path\/" \/>/,
+    );
+    assert.match(
+      (await request(app, `${basePath}/boards/base-path-board`)).body,
+      /\/custom\/base\/path\/boards\/base-path-board\?lang=en/,
+    );
+  } finally {
+    await closeServer(app);
+  }
+});
+
 test("board pages set an httpOnly user secret cookie when missing", async () => {
   const dirs = await createServerDirs();
 

--- a/test-node/templating.test.js
+++ b/test-node/templating.test.js
@@ -38,6 +38,7 @@ test("Template.parameters uses the first forwarded host and proto values", async
   );
 
   assert.equal(parameters.baseUrl, "https://example.com/prefix/");
+  assert.equal(parameters.baseHref, "https://example.com/prefix/");
 });
 
 test("Template.parameters prefers an exact region match over a loose base-language match", async () => {

--- a/types/server-runtime.d.ts
+++ b/types/server-runtime.d.ts
@@ -39,6 +39,7 @@ export type HttpRouteContext<
   response: HttpResponse;
   runtime: ServerRuntime;
   observed: ObservedHttpRequest;
+  publicUrl: URL;
   url: URL;
   params: Params;
 };


### PR DESCRIPTION
## Summary

Fixes WBO's existing reverse-proxy subpath handling for deployments mounted below a public base path, such as `/custom/base/path` or `/wbo`.

The app already inferred subpath prefixes in some rendered pages, but that support was incomplete: generated redirects, index links, canonical/base URLs, static file serving for prefixed requests, and the Socket.IO endpoint could still assume root hosting. This adds `WBO_BASE_PATH` as the explicit public path setting and applies it where generated public URLs or socket paths are produced, while keeping internal route matching root-based.

Fixes https://github.com/lovasoa/whitebophir/issues/360

## Validation

- `npm test`
- `npm run typecheck`
- `node --test test-node/server_routes.test.js test-node/templating.test.js`
- `npx playwright test playwright/tests/drawing.spec.ts -g "draws under a custom base path"`
- `git diff --check`