### PR TITLE
surface hand batch child deletes in optimistic prune plan

### DIFF
--- a/client-data/js/authoritative_mutation_effects.js
+++ b/client-data/js/authoritative_mutation_effects.js
@@ -1,4 +1,8 @@
-import { getMutationType, MutationType } from "./message_tool_metadata.js";
+import {
+  getMutationType,
+  getMutationTypeCode,
+  MutationType,
+} from "./message_tool_metadata.js";
 
 /**
  * @param {unknown} message
@@ -8,12 +12,30 @@ export function optimisticPrunePlanForAuthoritativeMessage(message) {
   if (!message || typeof message !== "object") {
     return { reset: false, invalidatedIds: [] };
   }
-  const normalizedMessage = /** @type {{type?: unknown, id?: unknown}} */ (
-    message
-  );
+  const normalizedMessage =
+    /** @type {{type?: unknown, id?: unknown, _children?: unknown}} */ (
+      message
+    );
   const mutationType = getMutationType(normalizedMessage);
   if (mutationType === MutationType.CLEAR) {
     return { reset: true, invalidatedIds: [] };
+  }
+  if (mutationType === MutationType.BATCH) {
+    /** @type {string[]} */
+    const invalidatedIds = [];
+    let reset = false;
+    for (const child of /** @type {{type?: unknown, id?: unknown}[]} */ (
+      normalizedMessage._children
+    )) {
+      const childType = getMutationTypeCode(child?.type);
+      if (childType === MutationType.CLEAR) reset = true;
+      else if (
+        childType === MutationType.DELETE &&
+        typeof child.id === "string"
+      )
+        invalidatedIds.push(child.id);
+    }
+    return { reset, invalidatedIds };
   }
   if (
     mutationType === MutationType.DELETE &&

--- a/test-node/optimistic_journal.test.js
+++ b/test-node/optimistic_journal.test.js
@@ -343,6 +343,70 @@ test("optimistic journal prunes entries invalidated by authoritative deletes", (
   );
 });
 
+test("authoritative prune plan surfaces hand batch child deletes and clears", () => {
+  assert.deepEqual(
+    optimisticPrunePlanForAuthoritativeMessage({
+      tool: Hand.id,
+      _children: [
+        { type: MutationType.DELETE, id: "shape-1" },
+        {
+          type: MutationType.UPDATE,
+          id: "shape-2",
+          transform: IDENTITY_TRANSFORM,
+        },
+        { type: MutationType.DELETE, id: "shape-3" },
+      ],
+    }),
+    { reset: false, invalidatedIds: ["shape-1", "shape-3"] },
+  );
+
+  assert.deepEqual(
+    optimisticPrunePlanForAuthoritativeMessage({
+      tool: Hand.id,
+      _children: [
+        { type: MutationType.DELETE, id: "shape-1" },
+        { type: MutationType.CLEAR },
+      ],
+    }),
+    { reset: true, invalidatedIds: ["shape-1"] },
+  );
+});
+
+test("optimistic journal prunes entries invalidated by hand batch child deletes", () => {
+  const journal = createOptimisticJournal();
+  appendOptimisticEntry(journal, {
+    clientMutationId: "c1",
+    affectedIds: new Set(["shape-1"]),
+    dependsOn: new Set(),
+    dependencyItemIds: new Set(["shape-1"]),
+    rollback: { kind: "items", snapshots: [] },
+    message: rectUpdate("shape-1"),
+  });
+  appendOptimisticEntry(journal, {
+    clientMutationId: "c2",
+    affectedIds: new Set(["shape-2"]),
+    dependsOn: new Set(),
+    dependencyItemIds: new Set(["shape-2"]),
+    rollback: { kind: "items", snapshots: [] },
+    message: rectUpdate("shape-2"),
+  });
+
+  const plan = optimisticPrunePlanForAuthoritativeMessage({
+    tool: Hand.id,
+    _children: [{ type: MutationType.DELETE, id: "shape-1" }],
+  });
+  assert.deepEqual(
+    journal
+      .rejectByInvalidatedIds(plan.invalidatedIds)
+      .map((entry) => entry.clientMutationId),
+    ["c1"],
+  );
+  assert.deepEqual(
+    journal.list().map((entry) => entry.clientMutationId),
+    ["c2"],
+  );
+});
+
 test("optimistic journal uses authoritative prune plans with dependency-driven entries", () => {
   const journal = createOptimisticJournal();
 


### PR DESCRIPTION
surface hand batch child deletes in optimistic prune plan

[`optimisticPrunePlanForAuthoritativeMessage()`](https://github.com/lovasoa/whitebophir/blob/master/client-data/js/authoritative_mutation_effects.js) only invalidated optimistic state for top-level `DELETE`/`CLEAR`. But [`getMutationType()`](https://github.com/lovasoa/whitebophir/blob/master/client-data/js/message_tool_metadata.js) returns `BATCH` whenever `_children` is present, so child deletes inside hand-tool selection batches ([`deleteSelection()`](https://github.com/lovasoa/whitebophir/blob/master/client-data/tools/hand/index.js)) were never surfaced. A peer deleting an item via hand selection while this client held pending optimistic writes for it would leave stale state that could later resurrect.

This adds a `BATCH` branch that walks `_children`, collecting every child `DELETE` id into `invalidatedIds` and treating a child `CLEAR` as `reset`. Top-level handling is unchanged.

Tested:

```
$ node --test test-node/optimistic_journal.test.js
# 10 tests, 10 pass, 0 fail
```

The 2 new tests cover a hand batch with child deletes (mixed with an UPDATE) and a child clear. `npm run lint` and `npm run typecheck` are clean.