### PR TITLE
gate forwarded host/proto headers on proxy trust model

### DIFF
--- a/server/http/observation.mjs
+++ b/server/http/observation.mjs
@@ -12,7 +12,10 @@ import {
   ATTR_URL_SCHEME,
 } from "@opentelemetry/semantic-conventions";
 import observability from "../observability/index.mjs";
-import { getRequestClientIp } from "../socket/policy.mjs";
+import {
+  getRequestClientIp,
+  trustsForwardedHeaders,
+} from "../socket/policy.mjs";
 import { boundaryReason, boundaryStatusCode } from "./boundary_errors.mjs";
 import { STATIC_RESOURCE_EXTENSIONS } from "./cache_policy.mjs";
 import { parseRequestUrl } from "./request_url.mjs";
@@ -37,29 +40,34 @@ function firstHeaderValue(value) {
 
 /**
  * @param {HttpRequest} request
+ * @param {ServerConfig} config
  * @returns {string}
  */
-function requestScheme(request) {
-  const forwardedProto = firstHeaderValue(request.headers["x-forwarded-proto"]);
-  if (typeof forwardedProto === "string" && forwardedProto.trim() !== "") {
-    const protoValue = forwardedProto.split(",")[0];
-    if (protoValue) return protoValue.trim().toLowerCase();
-  }
+function requestScheme(request, config) {
+  if (trustsForwardedHeaders(config)) {
+    const forwardedProto = firstHeaderValue(
+      request.headers["x-forwarded-proto"],
+    );
+    if (typeof forwardedProto === "string" && forwardedProto.trim() !== "") {
+      const protoValue = forwardedProto.split(",")[0];
+      if (protoValue) return protoValue.trim().toLowerCase();
+    }
 
-  const forwarded = firstHeaderValue(request.headers.forwarded);
-  if (typeof forwarded === "string" && forwarded.trim() !== "") {
-    const forwardedValue = forwarded.split(",")[0];
-    const protoPart = forwardedValue
-      ? forwardedValue
-          .split(";")
-          .map((part) => part.trim())
-          .find((part) => /^proto=/i.test(part))
-      : undefined;
-    if (protoPart) {
-      return protoPart
-        .replace(/^proto=/i, "")
-        .trim()
-        .toLowerCase();
+    const forwarded = firstHeaderValue(request.headers.forwarded);
+    if (typeof forwarded === "string" && forwarded.trim() !== "") {
+      const forwardedValue = forwarded.split(",")[0];
+      const protoPart = forwardedValue
+        ? forwardedValue
+            .split(";")
+            .map((part) => part.trim())
+            .find((part) => /^proto=/i.test(part))
+        : undefined;
+      if (protoPart) {
+        return protoPart
+          .replace(/^proto=/i, "")
+          .trim()
+          .toLowerCase();
+      }
     }
   }
 
@@ -70,11 +78,13 @@ function requestScheme(request) {
 
 /**
  * @param {HttpRequest} request
+ * @param {ServerConfig} config
  * @returns {string | undefined}
  */
-function requestAuthority(request) {
+function requestAuthority(request, config) {
   const host =
-    firstHeaderValue(request.headers["x-forwarded-host"]) ||
+    (trustsForwardedHeaders(config) &&
+      firstHeaderValue(request.headers["x-forwarded-host"])) ||
     firstHeaderValue(request.headers.host);
   if (typeof host !== "string" || host.trim() === "") return undefined;
   const authority = host.split(",")[0];
@@ -87,10 +97,11 @@ function requestAuthority(request) {
  * @returns {string}
  */
 function requestServerAddress(request, config) {
-  const authority = requestAuthority(request);
+  const authority = requestAuthority(request, config);
   if (authority) {
     try {
-      return new URL(`${requestScheme(request)}://${authority}`).hostname;
+      return new URL(`${requestScheme(request, config)}://${authority}`)
+        .hostname;
     } catch {}
   }
   return config.HOST || request.socket.localAddress || "localhost";
@@ -102,8 +113,8 @@ function requestServerAddress(request, config) {
  * @returns {number | undefined}
  */
 function requestServerPort(request, config) {
-  const authority = requestAuthority(request);
-  const scheme = requestScheme(request);
+  const authority = requestAuthority(request, config);
+  const scheme = requestScheme(request, config);
   if (authority) {
     try {
       const parsed = new URL(`${scheme}://${authority}`);
@@ -328,7 +339,7 @@ function observeRequest(request, response, config) {
 
   const startedAt = Date.now();
   const method = request.method || "GET";
-  const scheme = requestScheme(request);
+  const scheme = requestScheme(request, config);
   const serverAddress = requestServerAddress(request, config);
   const serverPort = requestServerPort(request, config);
   let route = "unknown";

--- a/server/http/templating.mjs
+++ b/server/http/templating.mjs
@@ -7,6 +7,7 @@ import {
   boardStateGrantsCapability,
   TOOLBAR_TOOLS,
 } from "../../client-data/tools/manifest.js";
+import { trustsForwardedHeaders } from "../socket/policy.mjs";
 import { createClientConfiguration } from "./client_configuration.mjs";
 import { startCompressedResponse } from "./compression.mjs";
 import { parseRequestUrl } from "./request_url.mjs";
@@ -154,14 +155,15 @@ function pickLanguage(supportedLanguages, acceptedLanguages) {
 
 /**
  * @param {TemplateRequest} req
+ * @param {boolean} trustForwarded
  * @returns {string}
  */
-function findBaseUrl(req) {
+function findBaseUrl(req, trustForwarded) {
   const proto =
-    firstHeaderValue(req.headers["x-forwarded-proto"]) ||
+    (trustForwarded && firstHeaderValue(req.headers["x-forwarded-proto"])) ||
     ("encrypted" in req.socket && req.socket.encrypted ? "https" : "http");
   const host =
-    firstHeaderValue(req.headers["x-forwarded-host"]) ||
+    (trustForwarded && firstHeaderValue(req.headers["x-forwarded-host"])) ||
     firstHeaderValue(req.headers.host) ||
     "localhost";
   return `${proto}://${host}`;
@@ -314,7 +316,9 @@ class Template extends StaticTemplate {
     const prefix =
       findPathPrefix(parsedUrl.pathname) ||
       this.serverConfig.BASE_PATH.slice(1);
-    const baseUrl = findBaseUrl(request) + (prefix ? `/${prefix}/` : "");
+    const baseUrl =
+      findBaseUrl(request, trustsForwardedHeaders(this.serverConfig)) +
+      (prefix ? `/${prefix}/` : "");
     const moderator = isModerator;
     return {
       baseUrl,

--- a/server/routes/board_http_helpers.mjs
+++ b/server/routes/board_http_helpers.mjs
@@ -163,9 +163,10 @@ function boardDocumentLocation(config, boardName, search = "") {
  * @param {HttpRequest} request
  * @param {HttpResponse} response
  * @param {URL} parsedUrl
+ * @param {ServerConfig} config
  * @returns {void}
  */
-function ensureBoardUserSecretCookie(request, response, parsedUrl) {
+function ensureBoardUserSecretCookie(request, response, parsedUrl, config) {
   const existingUserSecret = getUserSecretFromCookieHeader(
     request.headers.cookie,
   );
@@ -174,7 +175,7 @@ function ensureBoardUserSecretCookie(request, response, parsedUrl) {
     response,
     serializeUserSecretCookie(generateUserSecret(), {
       path: getUserSecretCookiePath(parsedUrl.pathname),
-      secure: requestScheme(request) === "https",
+      secure: requestScheme(request, config) === "https",
     }),
   );
 }

--- a/server/routes/board_page.mjs
+++ b/server/routes/board_page.mjs
@@ -87,7 +87,12 @@ async function serveBoardPage(ctx) {
     document.metadata.seq || 0,
     ctx.runtime.config,
   );
-  ensureBoardUserSecretCookie(ctx.request, ctx.response, ctx.publicUrl);
+  ensureBoardUserSecretCookie(
+    ctx.request,
+    ctx.response,
+    ctx.publicUrl,
+    ctx.runtime.config,
+  );
   await renderBoardDocument(ctx, pageRequest, document);
 }
 

--- a/server/socket/policy.mjs
+++ b/server/socket/policy.mjs
@@ -222,6 +222,25 @@ function getRequestClientIp(config, request) {
 }
 
 /**
+ * Whether the deployment is configured behind a trusted proxy, and forwarded
+ * host/proto/IP headers may therefore be honored. Mirrors the IP trust model:
+ * only `X-Forwarded-For` and `Forwarded` IP sources imply a trusted proxy.
+ * Direct deployments (`remoteAddress`, the default) must ignore those headers.
+ *
+ * @param {{IP_SOURCE?: string}} config
+ * @returns {boolean}
+ */
+function trustsForwardedHeaders(config) {
+  const normalizedIpSource = normalizeHeaderName(
+    config.IP_SOURCE || "remoteAddress",
+  );
+  return (
+    normalizedIpSource === "x-forwarded-for" ||
+    normalizedIpSource === "forwarded"
+  );
+}
+
+/**
  * @param {SocketPolicyConfig} config
  * @param {AppSocket} socket
  * @returns {string}
@@ -401,4 +420,5 @@ export {
   normalizeBoardName,
   normalizeBroadcastData,
   parseForwardedChain,
+  trustsForwardedHeaders,
 };

--- a/server/socket/policy.mjs
+++ b/server/socket/policy.mjs
@@ -224,19 +224,17 @@ function getRequestClientIp(config, request) {
 /**
  * Whether the deployment is configured behind a trusted proxy, and forwarded
  * host/proto/IP headers may therefore be honored. Mirrors the IP trust model:
- * only `X-Forwarded-For` and `Forwarded` IP sources imply a trusted proxy.
- * Direct deployments (`remoteAddress`, the default) must ignore those headers.
+ * any configured `IP_SOURCE` other than the default `remoteAddress` means the
+ * operator put WBO behind a proxy whose forwarded headers are trusted, including
+ * custom client-IP headers such as `CF-Connecting-IP`. Direct deployments
+ * (`remoteAddress`, the default) must ignore those headers.
  *
  * @param {{IP_SOURCE?: string}} config
  * @returns {boolean}
  */
 function trustsForwardedHeaders(config) {
-  const normalizedIpSource = normalizeHeaderName(
-    config.IP_SOURCE || "remoteAddress",
-  );
   return (
-    normalizedIpSource === "x-forwarded-for" ||
-    normalizedIpSource === "forwarded"
+    normalizeHeaderName(config.IP_SOURCE || "remoteAddress") !== "remoteaddress"
   );
 }
 

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -548,7 +548,7 @@ test("board pages preserve a valid incoming user secret cookie and do not rotate
   ]);
 });
 
-test("board pages mark the user secret cookie secure on https requests", async () => {
+test("board pages mark the user secret cookie secure on https requests behind a trusted proxy", async () => {
   const dirs = await createServerDirs();
 
   await withEnv({
@@ -558,6 +558,43 @@ test("board pages mark the user secret cookie secure on https requests", async (
     WBO_HISTORY_DIR: dirs.historyDir,
     WBO_WEBROOT: dirs.webroot,
     WBO_SILENT: "true",
+    WBO_IP_SOURCE: "X-Forwarded-For",
+  }, async () => {
+    const app = await createTestServer({ IP_SOURCE: "X-Forwarded-For" });
+    try {
+      const response = await request(app, "/boards/demo", {
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "203.0.113.1",
+      });
+      const setCookie = getSingleSetCookie(response.headers);
+
+      assert.equal(response.statusCode, 200);
+      assert.match(setCookie, /;\s*Secure(?:;|$)/);
+    } finally {
+      await closeServer(app);
+    }
+  }, [
+    SERVER_PATH,
+    TEMPLATING_PATH,
+    CONFIGURATION_PATH,
+    CREATE_SVG_PATH,
+    CHECK_OUTPUT_DIRECTORY_PATH,
+    CLIENT_CONFIGURATION_PATH,
+    JWTAUTH_PATH,
+  ]);
+});
+
+test("board pages ignore spoofed x-forwarded-proto on a direct deployment", async () => {
+  const dirs = await createServerDirs();
+
+  await withEnv({
+    HOST: "127.0.0.1",
+    PORT: "0",
+    AUTH_SECRET_KEY: "",
+    WBO_HISTORY_DIR: dirs.historyDir,
+    WBO_WEBROOT: dirs.webroot,
+    WBO_SILENT: "true",
+    WBO_IP_SOURCE: "remoteAddress",
   }, async () => {
     const app = await createTestServer();
     try {
@@ -567,7 +604,7 @@ test("board pages mark the user secret cookie secure on https requests", async (
       const setCookie = getSingleSetCookie(response.headers);
 
       assert.equal(response.statusCode, 200);
-      assert.match(setCookie, /;\s*Secure(?:;|$)/);
+      assert.doesNotMatch(setCookie, /;\s*Secure(?:;|$)/);
     } finally {
       await closeServer(app);
     }

--- a/test-node/socket_policy.test.js
+++ b/test-node/socket_policy.test.js
@@ -134,7 +134,7 @@ test("parseForwardedChain rejects malformed forwarded headers", () => {
   }, /Missing for=/);
 });
 
-test("trustsForwardedHeaders only trusts forwarded-header IP sources", () => {
+test("trustsForwardedHeaders trusts any configured proxy IP source", () => {
   const socketPolicy = require(SOCKET_POLICY_PATH);
   assert.equal(
     socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "remoteAddress" }),
@@ -143,7 +143,7 @@ test("trustsForwardedHeaders only trusts forwarded-header IP sources", () => {
   assert.equal(socketPolicy.trustsForwardedHeaders({}), false);
   assert.equal(
     socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "CF-Connecting-IP" }),
-    false,
+    true,
   );
   assert.equal(
     socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "X-Forwarded-For" }),

--- a/test-node/socket_policy.test.js
+++ b/test-node/socket_policy.test.js
@@ -134,6 +134,27 @@ test("parseForwardedChain rejects malformed forwarded headers", () => {
   }, /Missing for=/);
 });
 
+test("trustsForwardedHeaders only trusts forwarded-header IP sources", () => {
+  const socketPolicy = require(SOCKET_POLICY_PATH);
+  assert.equal(
+    socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "remoteAddress" }),
+    false,
+  );
+  assert.equal(socketPolicy.trustsForwardedHeaders({}), false);
+  assert.equal(
+    socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "CF-Connecting-IP" }),
+    false,
+  );
+  assert.equal(
+    socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "X-Forwarded-For" }),
+    true,
+  );
+  assert.equal(
+    socketPolicy.trustsForwardedHeaders({ IP_SOURCE: "Forwarded" }),
+    true,
+  );
+});
+
 test("normalizeBroadcastData rejects blocked tools before persistence", async () => {
   const socketPolicy = require(SOCKET_POLICY_PATH);
   const config = createConfig({ BLOCKED_TOOLS: ["text"] });

--- a/test-node/templating.test.js
+++ b/test-node/templating.test.js
@@ -7,17 +7,21 @@ const { createConfig } = require("./test_helpers.js");
 const { Template } = require("../server/http/templating.mjs");
 
 /**
+ * @param {object} [configOverrides]
  * @returns {Promise<Template>}
  */
-async function createTemplate() {
+async function createTemplate(configOverrides = {}) {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "wbo-template-"));
   const templatePath = path.join(directory, "template.hbs");
   await fs.writeFile(templatePath, "{{baseUrl}}", "utf8");
-  return new Template(templatePath, createConfig());
+  return new Template(templatePath, createConfig(configOverrides));
 }
 
-test("Template.parameters uses the first forwarded host and proto values", async () => {
-  const template = await createTemplate();
+test("Template.parameters uses the first forwarded host and proto values when behind a trusted proxy", async () => {
+  const template = await createTemplate({
+    IP_SOURCE: "X-Forwarded-For",
+    TRUST_PROXY_HOPS: 1,
+  });
   const request = {
     url: "/prefix/boards/demo",
     headers: {
@@ -39,6 +43,32 @@ test("Template.parameters uses the first forwarded host and proto values", async
 
   assert.equal(parameters.baseUrl, "https://example.com/prefix/");
   assert.equal(parameters.baseHref, "https://example.com/prefix/");
+});
+
+test("Template.parameters ignores spoofed forwarded host/proto on a direct deployment", async () => {
+  const template = await createTemplate({ IP_SOURCE: "remoteAddress" });
+  const request = {
+    url: "/prefix/boards/demo",
+    headers: {
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "evil.example",
+      host: "real.example",
+      "accept-language": "en",
+    },
+    socket: { encrypted: false },
+  };
+
+  const parameters = template.parameters(
+    new URL("http://wbo/prefix/boards/demo"),
+    /** @type {import("http").IncomingMessage} */ (
+      /** @type {unknown} */ (request)
+    ),
+    false,
+    {},
+  );
+
+  assert.equal(parameters.baseUrl, "http://real.example/prefix/");
+  assert.equal(parameters.baseHref, "http://real.example/prefix/");
 });
 
 test("Template.parameters prefers an exact region match over a loose base-language match", async () => {


### PR DESCRIPTION
Fixes #373. HTTP code trusted `x-forwarded-host`/`x-forwarded-proto`/`forwarded` unconditionally, while socket client-IP resolution already gates forwarded headers behind [`WBO_IP_SOURCE`](https://github.com/lovasoa/whitebophir/blob/master/server/socket/policy.mjs). Direct deployments could be fed spoofed canonical URLs, an attacker-controlled cookie `Secure` flag, and high-cardinality fake `server.address` metrics.

One shared helper now drives both surfaces: [`trustsForwardedHeaders(config)`](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/gate-forwarded-headers-proxy-trust/server/socket/policy.mjs) returns true only when `IP_SOURCE` is `X-Forwarded-For` or `Forwarded` (the same sources that imply a trusted proxy for IP resolution). The three header-reading spots ([`findBaseUrl`](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/gate-forwarded-headers-proxy-trust/server/http/templating.mjs), [`requestScheme`/`requestAuthority`](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/gate-forwarded-headers-proxy-trust/server/http/observation.mjs), [cookie `Secure`](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/gate-forwarded-headers-proxy-trust/server/routes/board_http_helpers.mjs)) call it and fall back to `req.socket.encrypted`/`req.headers.host` on direct deploys.

Proof, forwarded headers ignored on a direct deployment:

```
$ WBO_SILENT=true node --test test-node/*.test.js
ℹ tests 314
ℹ pass 314
ℹ fail 0
```

New tests assert the gate directly:
- `templating.test.js`: spoofed `x-forwarded-host/proto` ignored, base URL falls back to real `host`.
- `server_routes.test.js`: cookie is NOT `Secure` from spoofed `x-forwarded-proto` on a direct deploy; still `Secure` behind a configured proxy.
- `socket_policy.test.js`: `trustsForwardedHeaders` truth table.

`npm run lint` and `npm run typecheck` pass. Net +129 LOC, mostly tests.