### PR TITLE
Use a per-board save queue instead of a process-wide one

### DIFF
--- a/server/board/data.mjs
+++ b/server/board/data.mjs
@@ -83,6 +83,7 @@ import {
   trimOverflowItems as trimBoardOverflowItems,
 } from "./message_processing.mjs";
 import { createMutationLog } from "./mutation_log.mjs";
+import { SerialTaskQueue } from "./serial_task_queue.mjs";
 import {
   createDefaultSvgExtent,
   extendSvgExtentForItem,
@@ -204,6 +205,9 @@ class BoardData {
     this.saveInProgress = false;
     /** @type {ReturnType<typeof setTimeout> | undefined} */
     this.saveTimeoutId = undefined;
+    // Serializes this board's own disk writes. Owned by the instance so it is
+    // GC'd with the board and never blocks saves of unrelated boards.
+    this.saveQueue = new SerialTaskQueue();
     this.users = new Set();
     this.mutationLog = createMutationLog(0);
     /** @type {PendingMutationEffect[]} */

--- a/server/board/data_persistence.mjs
+++ b/server/board/data_persistence.mjs
@@ -13,14 +13,12 @@ import {
 } from "./canonical_index.mjs";
 import { createMutationLog } from "./mutation_log.mjs";
 import { getMinPinnedReplayBaselineSeq } from "./registry.mjs";
-import { SerialTaskQueue } from "./serial_task_queue.mjs";
 import { createDefaultSvgExtent } from "./svg_extent.mjs";
 
 const { logger, metrics, tracing } = observability;
 
 const STANDALONE_BOARD_LOAD_BYTES_THRESHOLD = 1024 * 1024;
 const STANDALONE_BOARD_SAVE_ITEM_COUNT_THRESHOLD = 2048;
-const boardSaveQueue = new SerialTaskQueue();
 
 /** @import { BoardData } from "./data.mjs" */
 /** @typedef {{actualFileSeq?: number, durationMs?: number, saveTargetSeq?: number}} StaleSaveDetails */
@@ -285,9 +283,9 @@ function trimPersistedMutationLog(board, nowMs = Date.now()) {
  */
 async function saveBoard(board) {
   if (board.disposed) return { status: "skipped" };
-  // Persisted board writes are serialized process-wide so only one board save
-  // mutates on-disk state at a time.
-  return boardSaveQueue.runExclusive(board._unsafe_save.bind(board));
+  // Writes are serialized per board (each board owns its files), so a slow save
+  // on one board never blocks saves of other boards.
+  return board.saveQueue.runExclusive(board._unsafe_save.bind(board));
 }
 
 /**

--- a/test-node/board_data.test.js
+++ b/test-node/board_data.test.js
@@ -1974,10 +1974,10 @@ test("BoardData.save serializes concurrent saves and releases after failure", as
   assert.ok(secondResolvedIndex > okIndex);
 });
 
-test("BoardData.save serializes concurrent saves across boards", async () => {
+test("BoardData.save runs concurrently across boards but stays serialized per board", async () => {
   const BoardData = getBoardDataClass();
-  const firstBoard = createBoard(BoardData, "global-save-queue-first");
-  const secondBoard = createBoard(BoardData, "global-save-queue-second");
+  const firstBoard = createBoard(BoardData, "per-board-save-queue-first");
+  const secondBoard = createBoard(BoardData, "per-board-save-queue-second");
   /** @type {string[]} */
   const calls = [];
   /** @type {(value?: void) => void} */
@@ -1998,23 +1998,47 @@ test("BoardData.save serializes concurrent saves across boards", async () => {
     return { status: "saved" };
   };
 
-  const firstSave = firstBoard.save().then(() => {
-    calls.push("first:resolved");
-  });
-  const secondSave = secondBoard.save().then(() => {
-    calls.push("second:resolved");
-  });
-
-  await Promise.resolve();
-  assert.deepEqual(calls, ["first:start"]);
+  // First board is mid-save (blocked on the gate). A save on the second,
+  // unrelated board must not wait behind it.
+  const firstSave = firstBoard.save();
+  const secondSave = secondBoard.save();
+  assert.deepEqual(await secondSave, { status: "saved" });
+  assert.deepEqual(calls, ["first:start", "second:start", "second:end"]);
 
   releaseFirstSave();
-  await Promise.all([firstSave, secondSave]);
+  assert.deepEqual(await firstSave, { status: "saved" });
+  assert.deepEqual(calls, [
+    "first:start",
+    "second:start",
+    "second:end",
+    "first:end",
+  ]);
 
-  assert.equal(calls[0], "first:start");
-  assert.equal(calls[1], "first:end");
-  assert.equal(calls[2], "second:start");
-  assert.equal(calls[3], "second:end");
-  assert.equal(calls.includes("first:resolved"), true);
-  assert.equal(calls[calls.length - 1], "second:resolved");
+  // Two saves of the SAME board are still serialized: the second waits for the
+  // first to finish before it starts.
+  calls.length = 0;
+  /** @type {(value?: void) => void} */
+  let releaseSecond = () => {};
+  const secondGate = new Promise((resolve) => {
+    releaseSecond = resolve;
+  });
+  let started = false;
+  firstBoard._unsafe_save = async () => {
+    if (!started) {
+      started = true;
+      calls.push("a:start");
+      await secondGate;
+      calls.push("a:end");
+      return { status: "saved" };
+    }
+    calls.push("b:start");
+    return { status: "saved" };
+  };
+  const saveA = firstBoard.save();
+  const saveB = firstBoard.save();
+  await Promise.resolve();
+  assert.deepEqual(calls, ["a:start"]);
+  releaseSecond();
+  await Promise.all([saveA, saveB]);
+  assert.deepEqual(calls, ["a:start", "a:end", "b:start"]);
 });


### PR DESCRIPTION
# Use a per-board save queue instead of a process-wide one

`saveBoard` ran every board's save through a single global `SerialTaskQueue`, so a slow rewrite on one board blocked unrelated boards from persisting and delayed shutdown saves. Each board only ever writes its own files, so the lane only needs to be per board.

The queue now lives on each `BoardData` instance ([data.mjs](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/per-board-save-queue/server/board/data.mjs#L207-L210)), so it is GC'd with the board (no global `Map` to clean up). [`saveBoard`](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/per-board-save-queue/server/board/data_persistence.mjs#L284-L289) now uses `board.saveQueue`. File writes stay safe because the queue still serializes each board's own writes, and no two boards share a file.

## Proof

The [test](https://github.com/lovasoa/whitebophir/blob/ophir.lojkine/per-board-save-queue/test-node/board_data.test.js#L2039) blocks board A mid-save and shows board B completes anyway, then shows two saves of the same board stay serialized:

```js
const firstSave = firstBoard.save();   // blocked on a gate
const secondSave = secondBoard.save();
assert.deepEqual(await secondSave, { status: "saved" });
assert.deepEqual(calls, ["first:start", "second:start", "second:end"]);
// same-board: second save starts only after the first ends
assert.deepEqual(calls, ["a:start", "a:end", "b:start"]);
```

```
$ npm run test-node
tests 311 / pass 311 / fail 0
$ npm run lint
Checked 202 files in 49ms. No fixes applied.
$ npm run typecheck   # tsc, no output = clean
```
