### PR TITLE
fix(hand): apply child deletes synchronously (#378)

### DIFF
--- a/client-data/tools/eraser/index.js
+++ b/client-data/tools/eraser/index.js
@@ -154,13 +154,22 @@ export function draw(state, data) {
     });
     return;
   }
-  const elem = state.board.svg.getElementById(data.id);
+  deleteBoardElementById(state.board, data.id);
+}
+
+/**
+ * Synchronously remove an element from the board by id.
+ * Shared so other tools (e.g. hand) can apply a delete without
+ * re-entering the async board message pipeline.
+ * @param {{ svg: { getElementById(id: string): Element | null }, drawingArea: { removeChild(node: Element): unknown } }} board
+ * @param {string} id
+ */
+export function deleteBoardElementById(board, id) {
+  const elem = board.svg.getElementById(id);
   if (elem === null) {
-    logFrontendEvent("warn", "tool.eraser.delete_missing_target", {
-      id: data.id,
-    });
+    logFrontendEvent("warn", "tool.eraser.delete_missing_target", { id });
   } else {
-    state.board.drawingArea.removeChild(elem);
+    board.drawingArea.removeChild(elem);
   }
 }
 

--- a/client-data/tools/hand/index.js
+++ b/client-data/tools/hand/index.js
@@ -34,6 +34,7 @@ import { logFrontendEvent } from "../../js/frontend_logging.js";
 import MessageCommon from "../../js/message_common.js";
 import { MutationType } from "../../js/message_tool_metadata.js";
 import { TOOL_CODE_BY_ID } from "../tool-order.js";
+import { deleteBoardElementById } from "../eraser/index.js";
 
 /** @import { ToolBootContext, ToolRuntimeModules } from "../../../types/app-runtime" */
 /** @typedef {{a:number, b:number, c:number, d:number, e:number, f:number}} TransformState */
@@ -1011,11 +1012,10 @@ export function draw(state, data, isLocal = false) {
       break;
     }
     case MutationType.DELETE:
-      state.Tools.messages.messageForTool({
-        tool: TOOL_CODE_BY_ID.eraser,
-        type: MutationType.DELETE,
-        id: data.id,
-      });
+      // Apply the delete synchronously rather than re-entering the async
+      // messageForTool() pipeline, so a hand batch delete completes before
+      // sequence state advances and does not re-trigger generic message hooks.
+      deleteBoardElementById(state.Tools.board, data.id);
       break;
   }
 }

--- a/client-data/tools/pencil/index.js
+++ b/client-data/tools/pencil/index.js
@@ -1120,17 +1120,37 @@ export function normalizeServerRenderedElement(state, line) {
 }
 
 /**
+ * @param {{type?: unknown, id?: unknown, _children?: unknown}} message
+ * @param {string} activeId
+ * @returns {boolean}
+ */
+function messageDeletesActiveStroke(message, activeId) {
+  if (message.type === MutationType.DELETE && message.id === activeId) {
+    return true;
+  }
+  if (!Array.isArray(message._children)) return false;
+  for (const child of message._children) {
+    if (!child || typeof child !== "object") continue;
+    const record = /** @type {{type?: unknown, id?: unknown}} */ (child);
+    if (record.type === MutationType.DELETE && record.id === activeId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Handles authoritative board events that invalidate the active local stroke.
  * The overlay is local-only, so clear/delete must explicitly discard it.
+ * Hand selection deletes arrive as a batch, so child deletes are inspected too.
  * @param {PencilState} state
- * @param {{type?: unknown, id?: string}} message
+ * @param {{type?: unknown, id?: string, _children?: unknown}} message
  */
 export function onMessage(state, message) {
-  if (message.type === MutationType.CLEAR) {
-    clearActiveStrokeState(state);
-    return;
-  }
-  if (message.type === MutationType.DELETE && message.id === state.curLineId) {
+  if (
+    message.type === MutationType.CLEAR ||
+    messageDeletesActiveStroke(message, state.curLineId)
+  ) {
     clearActiveStrokeState(state);
   }
 }

--- a/test-node/client_tool_replay.test.js
+++ b/test-node/client_tool_replay.test.js
@@ -1166,6 +1166,31 @@ test("Pencil input sends an initial child point without DOM setup", () => {
   });
 });
 
+test("Pencil onMessage discards the active stroke deleted inside a hand batch", () => {
+  const tools = createInputTools();
+  const state = PencilTool.boot(
+    createToolBootContext(
+      createInputToolRuntime(tools),
+      (assetFile) => assetFile,
+    ),
+  );
+  state.curLineId = "l-7";
+
+  PencilTool.onMessage(state, {
+    _children: [
+      { type: MutationType.DELETE, id: "l-other" },
+      { type: MutationType.DELETE, id: "l-7" },
+    ],
+  });
+  assert.equal(state.curLineId, "");
+
+  state.curLineId = "l-8";
+  PencilTool.onMessage(state, {
+    _children: [{ type: MutationType.DELETE, id: "l-other" }],
+  });
+  assert.equal(state.curLineId, "l-8");
+});
+
 test("Pencil move logic sends the first point and throttles follow-ups", () => {
   const tools = createInputTools();
   const state = PencilTool.boot(

--- a/test-node/client_tool_replay.test.js
+++ b/test-node/client_tool_replay.test.js
@@ -2082,6 +2082,48 @@ test("Hand replay expands viewport extent for transform-only updates", async () 
   ]);
 });
 
+test("Hand batch delete removes the element synchronously without re-entering messageForTool", async () => {
+  const harness = createHarness();
+  const handTool = await harness.loadTool("hand");
+
+  const rect = globalAny.Tools.dom.createSVGElement("rect");
+  rect.id = "doomed-rect";
+  globalAny.Tools.drawingArea.appendChild(rect);
+  assert.ok(globalAny.Tools.dom.svg.getElementById("doomed-rect"));
+
+  // Spy on the generic async message pipeline. A hand child delete must not
+  // re-enter it (no derived child op, no duplicate generic side effects).
+  let messageForToolCalls = 0;
+  const originalMessageForTool = globalAny.Tools.messages.messageForTool;
+  globalAny.Tools.messages.messageForTool = (/** @type {any} */ data) => {
+    messageForToolCalls += 1;
+    return originalMessageForTool(data);
+  };
+
+  try {
+    const result = handTool.draw(
+      {
+        tool: TOOL_CODE_BY_ID.hand,
+        _children: [
+          {
+            type: MessageToolMetadata.MutationType.DELETE,
+            id: "doomed-rect",
+          },
+        ],
+      },
+      false,
+    );
+
+    // draw() returned and the element is already gone: applied synchronously
+    // before any sequence-advancing await could resolve.
+    assert.equal(result instanceof Promise, false);
+    assert.ok(!globalAny.Tools.dom.svg.getElementById("doomed-rect"));
+    assert.equal(messageForToolCalls, 0);
+  } finally {
+    globalAny.Tools.messages.messageForTool = originalMessageForTool;
+  }
+});
+
 test("Hand selector stops at the last valid transform", async () => {
   const harness = createHarness();
   const handTool = await harness.loadTool("hand");


### PR DESCRIPTION
# apply hand child deletes synchronously (#378)

A hand batch DELETE re-entered the async [`messageForTool()`](https://github.com/lovasoa/whitebophir/blob/master/client-data/js/board_message_module.js) pipeline to perform a derived eraser delete. That call is async (it can lazy-boot tools) and `hand.draw()` did not await it, while [replay](https://github.com/lovasoa/whitebophir/blob/master/client-data/js/board_replay_module.js) only awaits the top-level hand message. So sequence state could advance before the child delete applied, and the derived child op re-ran generic message hooks/tool notifications.

Fix: factor the eraser's synchronous element removal into [`deleteBoardElementById()`](https://github.com/lovasoa/whitebophir/blob/60bdddbf727f897c9cf251655bb4fca8f8b79f27/client-data/tools/eraser/index.js#L157-L171) and call it directly from [`hand.draw()`](https://github.com/lovasoa/whitebophir/blob/60bdddbf727f897c9cf251655bb4fca8f8b79f27/client-data/tools/hand/index.js#L1014-L1018). No re-entry into the generic pipeline.

Proof: new replay test asserts the element is gone right after `draw()` returns (non-Promise) and `messageForTool` was called 0 times.

```
$ WBO_SILENT=true node --test test-node/*.test.js
tests 312
pass 312
fail 0
```

`npm run lint` and `npm run typecheck` both clean.
