### PR TITLE
tool contracts: single DOM-free source of truth

### DIFF
--- a/client-data/js/message_common.js
+++ b/client-data/js/message_common.js
@@ -16,7 +16,7 @@
  *   _children?: Array<ChildPoint | null | undefined>
  * }} GeometryItem
  */
-import { DRAW_TOOL_IDS, TOOL_IDS } from "../tools/tool-order.js";
+import { DRAW_TOOL_IDS, TOOL_ID_BY_CODE } from "../tools/tool-order.js";
 import {
   clampCoord,
   clampOpacity,
@@ -40,10 +40,9 @@ function normalizeToolId(tool) {
   if (
     typeof tool === "number" &&
     Number.isSafeInteger(tool) &&
-    tool >= 1 &&
-    tool <= TOOL_IDS.length
+    Object.prototype.hasOwnProperty.call(TOOL_ID_BY_CODE, tool)
   ) {
-    return TOOL_IDS[tool - 1];
+    return TOOL_ID_BY_CODE[tool];
   }
   return undefined;
 }

--- a/client-data/js/message_tool_metadata.js
+++ b/client-data/js/message_tool_metadata.js
@@ -1,4 +1,4 @@
-import { TOOL_BY_CODE, TOOL_BY_ID, TOOL_IDS } from "../tools/manifest.js";
+import { TOOL_BY_ID, TOOL_ID_BY_CODE } from "../tools/manifest.js";
 import { getMutationTypeCode, MutationType } from "./mutation_type.js";
 
 /** @typedef {import("../../types/app-runtime").ToolCode} ToolCode */
@@ -22,8 +22,7 @@ const MUTATION_TYPE_NAME_BY_CODE = Object.freeze({
 export function getToolCode(tool) {
   return typeof tool === "number" &&
     Number.isSafeInteger(tool) &&
-    tool >= 1 &&
-    tool <= TOOL_IDS.length
+    Object.prototype.hasOwnProperty.call(TOOL_ID_BY_CODE, tool)
     ? /** @type {ToolCode} */ (tool)
     : undefined;
 }
@@ -34,14 +33,14 @@ export function getToolId(tool) {
     return TOOL_BY_ID[tool] ? tool : undefined;
   }
   const toolCode = getToolCode(tool);
-  return toolCode === undefined ? undefined : TOOL_IDS[toolCode - 1];
+  return toolCode === undefined ? undefined : TOOL_ID_BY_CODE[toolCode];
 }
 
 /** @param {unknown} tool */
 export function getTool(tool) {
   if (typeof tool === "string") return TOOL_BY_ID[tool];
-  const toolCode = getToolCode(tool);
-  return toolCode === undefined ? undefined : TOOL_BY_CODE[toolCode - 1];
+  const toolId = getToolId(tool);
+  return toolId === undefined ? undefined : TOOL_BY_ID[toolId];
 }
 
 /** @param {unknown} tool */

--- a/client-data/tools/contracts.js
+++ b/client-data/tools/contracts.js
@@ -1,0 +1,430 @@
+/**
+ * DOM-free tool contracts: the single source of truth for protocol/storage
+ * metadata that server hot paths (validation, persistence, canonical items)
+ * import. Built from the manifest plus per-tool storage contracts that depend
+ * only on other DOM-free helpers, so a browser/DOM import inside a tool module
+ * can never reach server startup, validation, or persistence.
+ */
+
+import { getLocalGeometryBounds } from "../js/message_common.js";
+import { TOOL_CODE_BY_ID, TOOL_ID_BY_CODE, TOOL_MANIFEST } from "./manifest.js";
+import {
+  renderPencilPath,
+  scanPathSummary,
+  serializeStoredPencilPath,
+} from "./pencil/pencil_path.js";
+import {
+  defineShapeContract,
+  normalizeRectBounds,
+  serializeStoredShapeTag,
+  summarizeStoredShape,
+} from "./shape_contract.js";
+
+/** @typedef {import("./shape_contract.js").ToolContract} ToolContract */
+
+/** @type {ToolContract} */
+const pencilContract = {
+  toolId: "pencil",
+  toolCode: TOOL_CODE_BY_ID.pencil,
+  payloadKind: "children",
+  storedTagName: "path",
+  summarizeStoredSvgItem(entry, paintOrder, helpers) {
+    const size = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "stroke-width"),
+    );
+    const scanned = scanPathSummary(helpers.readStoredSvgAttribute(entry, "d"));
+    if (size === undefined || scanned.childCount === 0) return null;
+    return {
+      id: helpers.id,
+      tool: "pencil",
+      data: helpers.decorateStoredItemData(
+        {
+          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
+          size,
+        },
+        helpers.opacity,
+        helpers.transform,
+      ),
+      childCount: scanned.childCount,
+      paintOrder,
+      localBounds: scanned.localBounds,
+    };
+  },
+  serializeStoredSvgItem(item, helpers) {
+    const points = Array.isArray(item._children) ? item._children : [];
+    const pathData = renderPencilPath(points);
+    return serializeStoredPencilPath(item, pathData, helpers);
+  },
+  renderBoardSvg(pencil, helpers) {
+    const pathstring = renderPencilPath(pencil._children || []);
+    return helpers.renderPath(pencil, pathstring);
+  },
+};
+
+const rectangleContract = defineShapeContract({
+  toolId: "rectangle",
+  toolCode: TOOL_CODE_BY_ID.rectangle,
+  storedTagName: "rect",
+  updatableFields: /** @type {const} */ (["x", "y", "x2", "y2"]),
+  summarizeStoredSvgItem(entry, paintOrder, helpers) {
+    const x = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x"));
+    const y = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y"));
+    const width = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "width"),
+    );
+    const height = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "height"),
+    );
+    const size = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "stroke-width"),
+    );
+    if (
+      x === undefined ||
+      y === undefined ||
+      width === undefined ||
+      height === undefined ||
+      size === undefined
+    ) {
+      return null;
+    }
+    return summarizeStoredShape(
+      {
+        id: helpers.id,
+        tool: "rectangle",
+        paintOrder,
+        data: {
+          x,
+          y,
+          x2: x + width,
+          y2: y + height,
+          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
+          size,
+        },
+        localBounds: {
+          minX: x,
+          minY: y,
+          maxX: x + width,
+          maxY: y + height,
+        },
+      },
+      helpers.opacity,
+      helpers.transform,
+      helpers.decorateStoredItemData,
+    );
+  },
+  serializeStoredSvgItem(item, helpers) {
+    const bounds = normalizeRectBounds(
+      helpers.numberOrZero(item.x),
+      helpers.numberOrZero(item.y),
+      helpers.numberOrZero(item.x2),
+      helpers.numberOrZero(item.y2),
+    );
+    return serializeStoredShapeTag(
+      "rect",
+      ` x="${bounds.x}" y="${bounds.y}" width="${bounds.width}" height="${bounds.height}"`,
+      item,
+      helpers,
+    );
+  },
+  renderBoardSvg(shape, helpers) {
+    const bounds = normalizeRectBounds(
+      helpers.numberOrZero(shape.x),
+      helpers.numberOrZero(shape.y),
+      helpers.numberOrZero(shape.x2),
+      helpers.numberOrZero(shape.y2),
+    );
+    return (
+      "<rect " +
+      (shape.id ? `id="${helpers.htmlspecialchars(shape.id)}" ` : "") +
+      `x="${bounds.x}" y="${bounds.y}" width="${bounds.width}" height="${bounds.height}" ` +
+      `stroke="${helpers.htmlspecialchars(shape.color || "#000")}" stroke-width="${helpers.numberOrZero(shape.size) | 0}" ` +
+      helpers.renderTranslate(shape) +
+      "/>"
+    );
+  },
+});
+
+const ellipseContract = defineShapeContract({
+  toolId: "ellipse",
+  toolCode: TOOL_CODE_BY_ID.ellipse,
+  storedTagName: "ellipse",
+  updatableFields: /** @type {const} */ (["x", "y", "x2", "y2"]),
+  summarizeStoredSvgItem(entry, paintOrder, helpers) {
+    const cx = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "cx"));
+    const cy = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "cy"));
+    const rx = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "rx"));
+    const ry = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "ry"));
+    const size = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "stroke-width"),
+    );
+    if (
+      cx === undefined ||
+      cy === undefined ||
+      rx === undefined ||
+      ry === undefined ||
+      size === undefined
+    ) {
+      return null;
+    }
+    return summarizeStoredShape(
+      {
+        id: helpers.id,
+        tool: "ellipse",
+        paintOrder,
+        data: {
+          x: cx - rx,
+          y: cy - ry,
+          x2: cx + rx,
+          y2: cy + ry,
+          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
+          size,
+        },
+        localBounds: {
+          minX: cx - rx,
+          minY: cy - ry,
+          maxX: cx + rx,
+          maxY: cy + ry,
+        },
+      },
+      helpers.opacity,
+      helpers.transform,
+      helpers.decorateStoredItemData,
+    );
+  },
+  serializeStoredSvgItem(item, helpers) {
+    const x = helpers.numberOrZero(item.x);
+    const y = helpers.numberOrZero(item.y);
+    const x2 = helpers.numberOrZero(item.x2);
+    const y2 = helpers.numberOrZero(item.y2);
+    return serializeStoredShapeTag(
+      "ellipse",
+      ` cx="${Math.round((x + x2) / 2)}" cy="${Math.round((y + y2) / 2)}" rx="${Math.abs(x2 - x) / 2}" ry="${Math.abs(y2 - y) / 2}"`,
+      item,
+      helpers,
+    );
+  },
+  renderBoardSvg(shape, helpers) {
+    const x = helpers.numberOrZero(shape.x);
+    const y = helpers.numberOrZero(shape.y);
+    const x2 = helpers.numberOrZero(shape.x2);
+    const y2 = helpers.numberOrZero(shape.y2);
+    const cx = Math.round((x2 + x) / 2);
+    const cy = Math.round((y2 + y) / 2);
+    const rx = Math.abs(x2 - x) / 2;
+    const ry = Math.abs(y2 - y) / 2;
+    return helpers.renderPath(
+      shape,
+      `M${cx - rx} ${cy}a${rx},${ry} 0 1,0 ${rx * 2},0a${rx},${ry} 0 1,0 ${rx * -2},0`,
+    );
+  },
+});
+
+const straightLineContract = defineShapeContract({
+  toolId: "straight-line",
+  toolCode: TOOL_CODE_BY_ID["straight-line"],
+  storedTagName: "line",
+  updatableFields: /** @type {const} */ (["x2", "y2"]),
+  summarizeStoredSvgItem(entry, paintOrder, helpers) {
+    const x1 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x1"));
+    const y1 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y1"));
+    const x2 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x2"));
+    const y2 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y2"));
+    const size = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "stroke-width"),
+    );
+    if (
+      x1 === undefined ||
+      y1 === undefined ||
+      x2 === undefined ||
+      y2 === undefined ||
+      size === undefined
+    ) {
+      return null;
+    }
+    return summarizeStoredShape(
+      {
+        id: helpers.id,
+        tool: "straight-line",
+        paintOrder,
+        data: {
+          x: x1,
+          y: y1,
+          x2,
+          y2,
+          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
+          size,
+        },
+        localBounds: {
+          minX: Math.min(x1, x2),
+          minY: Math.min(y1, y2),
+          maxX: Math.max(x1, x2),
+          maxY: Math.max(y1, y2),
+        },
+      },
+      helpers.opacity,
+      helpers.transform,
+      helpers.decorateStoredItemData,
+    );
+  },
+  serializeStoredSvgItem(item, helpers) {
+    return serializeStoredShapeTag(
+      "line",
+      ` x1="${helpers.numberOrZero(item.x)}" y1="${helpers.numberOrZero(item.y)}"` +
+        ` x2="${helpers.numberOrZero(item.x2)}" y2="${helpers.numberOrZero(item.y2)}"`,
+      item,
+      helpers,
+    );
+  },
+  renderBoardSvg(shape, helpers) {
+    return helpers.renderPath(
+      shape,
+      `M${shape.x} ${shape.y}L${shape.x2} ${shape.y2}`,
+    );
+  },
+});
+
+/** @type {ToolContract} */
+const textContract = {
+  toolId: "text",
+  toolCode: TOOL_CODE_BY_ID.text,
+  payloadKind: "text",
+  storedTagName: "text",
+  updatableFields: /** @type {const} */ (["txt"]),
+  summarizeStoredSvgItem(entry, paintOrder, helpers) {
+    const x = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x"));
+    const y = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y"));
+    const size = helpers.parseNumber(
+      helpers.readStoredSvgAttribute(entry, "font-size"),
+    );
+    if (x === undefined || y === undefined || size === undefined) {
+      return null;
+    }
+    const textLength = helpers.decodedTextLength(entry.content || "");
+    return {
+      id: helpers.id,
+      tool: "text",
+      paintOrder,
+      data: helpers.decorateStoredItemData(
+        {
+          x,
+          y,
+          size,
+          color: helpers.readStoredSvgAttribute(entry, "fill") || "#000000",
+        },
+        helpers.opacity,
+        helpers.transform,
+      ),
+      textLength,
+      localBounds: getLocalGeometryBounds({
+        tool: "text",
+        x,
+        y,
+        size,
+        textLength,
+      }),
+    };
+  },
+  parseStoredSvgItem(summary, entry, helpers) {
+    return {
+      id: summary.id,
+      tool: "text",
+      ...summary.data,
+      txt: helpers.unescapeHtml(entry.content || ""),
+    };
+  },
+  serializeStoredSvgItem(item, helpers) {
+    const transform = helpers.renderTransformAttribute(item.transform);
+    const id = typeof item.id === "string" ? helpers.escapeHtml(item.id) : "";
+    const color = helpers.escapeHtml(item.color || "#000000");
+    const opacity =
+      typeof item.opacity === "number" ? ` opacity="${item.opacity}"` : "";
+    const textValue = String(item.txt || "");
+    return (
+      `<text id="${id}" x="${helpers.numberOrZero(item.x)}" y="${helpers.numberOrZero(item.y)}"` +
+      ` font-size="${helpers.numberOrZero(item.size) | 0}" fill="${color}"${opacity}${transform}>` +
+      `${helpers.escapeHtml(textValue)}</text>`
+    );
+  },
+  renderBoardSvg(text, helpers) {
+    const x = helpers.numberOrZero(text.x);
+    const y = helpers.numberOrZero(text.y);
+    return (
+      "<text " +
+      'id="' +
+      helpers.htmlspecialchars(text.id || "t") +
+      '" ' +
+      'x="' +
+      (x | 0) +
+      '" ' +
+      'y="' +
+      (y | 0) +
+      '" ' +
+      'font-size="' +
+      (helpers.numberOrZero(text.size) | 0) +
+      '" ' +
+      'fill="' +
+      helpers.htmlspecialchars(text.color || "#000") +
+      '" ' +
+      helpers.renderTranslate(text) +
+      ">" +
+      helpers.htmlspecialchars(text.txt || "") +
+      "</text>"
+    );
+  },
+};
+
+/**
+ * Storage contracts keyed by tool id. The single source for the contract
+ * methods consumed by persistence/render; tool runtime modules re-export their
+ * entry from here so there is exactly one definition per tool.
+ * @type {Readonly<Record<string, ToolContract>>}
+ */
+export const STORAGE_CONTRACT_BY_ID = Object.freeze({
+  pencil: pencilContract,
+  rectangle: rectangleContract,
+  ellipse: ellipseContract,
+  "straight-line": straightLineContract,
+  text: textContract,
+});
+
+export const PencilContract = pencilContract;
+export const RectangleContract = rectangleContract;
+export const EllipseContract = ellipseContract;
+export const StraightLineContract = straightLineContract;
+export const TextContract = textContract;
+
+/**
+ * Server-safe tool contracts: manifest metadata merged with the storage
+ * contract methods, one entry per tool, ordered by manifest order.
+ * @type {ReadonlyArray<Readonly<import("./manifest.js").ToolManifestEntry & Partial<ToolContract>>>}
+ */
+export const TOOL_CONTRACTS = Object.freeze(
+  TOOL_MANIFEST.map((entry) =>
+    Object.freeze({
+      ...entry,
+      ...(STORAGE_CONTRACT_BY_ID[entry.toolId] || {}),
+    }),
+  ),
+);
+
+export const TOOL_CONTRACT_BY_ID = Object.freeze(
+  Object.fromEntries(TOOL_CONTRACTS.map((tool) => [tool.toolId, tool])),
+);
+
+export const TOOL_CONTRACT_BY_CODE = TOOL_CONTRACTS;
+
+export const TOOL_CONTRACT_BY_STORED_TAG_NAME = Object.freeze(
+  Object.fromEntries(
+    TOOL_CONTRACTS.filter((tool) => typeof tool.storedTagName === "string").map(
+      (tool) => [tool.storedTagName, tool],
+    ),
+  ),
+);
+
+export const Cursor =
+  /** @type {Readonly<import("./manifest.js").ToolManifestEntry & Partial<ToolContract>>} */ (
+    TOOL_CONTRACT_BY_ID.cursor
+  );
+
+export { TOOL_ID_BY_CODE };
+export { renderPencilPath, scanPathSummary } from "./pencil/pencil_path.js";

--- a/client-data/tools/ellipse/index.js
+++ b/client-data/tools/ellipse/index.js
@@ -1,3 +1,4 @@
+import { EllipseContract } from "../contracts.js";
 import {
   constrainEqualSpanToBoard,
   createShapeToolBoot,
@@ -5,7 +6,6 @@ import {
   makeSeedShapeCreateMessage,
   moveShapeTool,
 } from "../shape_tool.js";
-import { TOOL_CODE_BY_ID } from "../tool-order.js";
 
 export {
   cancelShapeToolTouchGesture as cancelTouchGesture,
@@ -15,91 +15,11 @@ export {
   releaseShapeTool as release,
 } from "../shape_tool.js";
 
-import {
-  defineShapeContract,
-  serializeStoredShapeTag,
-  summarizeStoredShape,
-} from "../shape_contract.js";
-
 export const toolId = "ellipse";
-const toolCode = TOOL_CODE_BY_ID[toolId];
 export const drawsOnBoard = true;
 export const mouseCursor = "crosshair";
 
-const contract = defineShapeContract({
-  toolId,
-  toolCode,
-  storedTagName: "ellipse",
-  updatableFields: /** @type {const} */ (["x", "y", "x2", "y2"]),
-  summarizeStoredSvgItem(entry, paintOrder, helpers) {
-    const cx = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "cx"));
-    const cy = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "cy"));
-    const rx = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "rx"));
-    const ry = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "ry"));
-    const size = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "stroke-width"),
-    );
-    if (
-      cx === undefined ||
-      cy === undefined ||
-      rx === undefined ||
-      ry === undefined ||
-      size === undefined
-    ) {
-      return null;
-    }
-    return summarizeStoredShape(
-      {
-        id: helpers.id,
-        tool: toolId,
-        paintOrder,
-        data: {
-          x: cx - rx,
-          y: cy - ry,
-          x2: cx + rx,
-          y2: cy + ry,
-          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
-          size,
-        },
-        localBounds: {
-          minX: cx - rx,
-          minY: cy - ry,
-          maxX: cx + rx,
-          maxY: cy + ry,
-        },
-      },
-      helpers.opacity,
-      helpers.transform,
-      helpers.decorateStoredItemData,
-    );
-  },
-  serializeStoredSvgItem(item, helpers) {
-    const x = helpers.numberOrZero(item.x);
-    const y = helpers.numberOrZero(item.y);
-    const x2 = helpers.numberOrZero(item.x2);
-    const y2 = helpers.numberOrZero(item.y2);
-    return serializeStoredShapeTag(
-      "ellipse",
-      ` cx="${Math.round((x + x2) / 2)}" cy="${Math.round((y + y2) / 2)}" rx="${Math.abs(x2 - x) / 2}" ry="${Math.abs(y2 - y) / 2}"`,
-      item,
-      helpers,
-    );
-  },
-  renderBoardSvg(shape, helpers) {
-    const x = helpers.numberOrZero(shape.x);
-    const y = helpers.numberOrZero(shape.y);
-    const x2 = helpers.numberOrZero(shape.x2);
-    const y2 = helpers.numberOrZero(shape.y2);
-    const cx = Math.round((x2 + x) / 2);
-    const cy = Math.round((y2 + y) / 2);
-    const rx = Math.abs(x2 - x) / 2;
-    const ry = Math.abs(y2 - y) / 2;
-    return helpers.renderPath(
-      shape,
-      `M${cx - rx} ${cy}a${rx},${ry} 0 1,0 ${rx * 2},0a${rx},${ry} 0 1,0 ${rx * -2},0`,
-    );
-  },
-});
+const contract = EllipseContract;
 
 /** @typedef {import("../shape_tool.js").ShapeCreateMessage<typeof contract.toolCode>} EllipseCreateMessage */
 /** @typedef {import("../shape_tool.js").ShapeBoxUpdateMessage<typeof contract.toolCode>} EllipseUpdateMessage */

--- a/client-data/tools/pencil/index.js
+++ b/client-data/tools/pencil/index.js
@@ -27,7 +27,14 @@
 import { logFrontendEvent } from "../../js/frontend_logging.js";
 import { LIMITS } from "../../js/message_common.js";
 import { MutationType } from "../../js/mutation_type.js";
+import { PencilContract } from "../contracts.js";
 import { TOOL_CODE_BY_ID } from "../tool-order.js";
+import {
+  appendPersistedPencilPath,
+  renderPencilPath,
+  scanPathSummary,
+  serializeStoredPencilPath,
+} from "./pencil_path.js";
 import { wboPencilPoint } from "./wbo_pencil_point.js";
 
 /** @import { ToolBootContext, ToolRuntimeModules } from "../../../types/app-runtime" */
@@ -62,220 +69,6 @@ function isPencilMessage(data) {
   );
 }
 
-/**
- * @param {number} value
- * @returns {number}
- */
-function roundPathValue(value) {
-  return Math.round(value);
-}
-
-/**
- * Parse a canonical persisted pencil path emitted by renderPencilPath:
- * `M <x> <y> l <dx> <dy> ...`
- *
- * @param {string} d
- * @param {number} index
- * @returns {{value: number, index: number} | null}
- */
-function readCanonicalPathInteger(d, index) {
-  const length = d.length;
-  let next = index;
-  let sign = 1;
-  if (next < length && d.charCodeAt(next) === 45) {
-    sign = -1;
-    next += 1;
-  }
-  if (next >= length) return null;
-  let code = d.charCodeAt(next) - 48;
-  if (code < 0 || code > 9) return null;
-  let value = 0;
-  while (next < length && code >= 0 && code <= 9) {
-    value = value * 10 + code;
-    next += 1;
-    if (next >= length) break;
-    code = d.charCodeAt(next) - 48;
-  }
-  return { value: sign * value, index: next };
-}
-
-/**
- * @param {string | undefined} d
- * @returns {{
- *   childCount: number,
- *   localBounds: {minX: number, minY: number, maxX: number, maxY: number} | null,
- *   lastPoint: {x: number, y: number} | null,
- * }}
- */
-const EMPTY_PERSISTED_PENCIL_SCAN = {
-  childCount: 0,
-  localBounds: null,
-  lastPoint: null,
-};
-
-/**
- * @param {string | undefined} d
- * @returns {{
- *   childCount: number,
- *   localBounds: {minX: number, minY: number, maxX: number, maxY: number} | null,
- *   lastPoint: {x: number, y: number} | null,
- * }}
- */
-function scanPersistedPencilPath(d) {
-  if (typeof d !== "string" || d === "") return EMPTY_PERSISTED_PENCIL_SCAN;
-  const length = d.length;
-  if (length < 5 || d.charCodeAt(0) !== 77 || d.charCodeAt(1) !== 32)
-    return EMPTY_PERSISTED_PENCIL_SCAN;
-
-  let index = 2;
-  const firstX = readCanonicalPathInteger(d, index);
-  if (!firstX || firstX.index >= length || d.charCodeAt(firstX.index) !== 32)
-    return EMPTY_PERSISTED_PENCIL_SCAN;
-  index = firstX.index + 1;
-  const firstY = readCanonicalPathInteger(d, index);
-  if (!firstY) return EMPTY_PERSISTED_PENCIL_SCAN;
-  index = firstY.index;
-
-  let currentX = firstX.value;
-  let currentY = firstY.value;
-  let minX = currentX;
-  let minY = currentY;
-  let maxX = currentX;
-  let maxY = currentY;
-  let childCount = 1;
-  let previousDistinctX = currentX;
-  let previousDistinctY = currentY;
-
-  while (index < length) {
-    if (
-      index + 2 >= length ||
-      d.charCodeAt(index) !== 32 ||
-      d.charCodeAt(index + 1) !== 108 ||
-      d.charCodeAt(index + 2) !== 32
-    ) {
-      return EMPTY_PERSISTED_PENCIL_SCAN;
-    }
-    index += 3;
-    const deltaX = readCanonicalPathInteger(d, index);
-    if (!deltaX || deltaX.index >= length || d.charCodeAt(deltaX.index) !== 32)
-      return EMPTY_PERSISTED_PENCIL_SCAN;
-    index = deltaX.index + 1;
-    const deltaY = readCanonicalPathInteger(d, index);
-    if (!deltaY) return EMPTY_PERSISTED_PENCIL_SCAN;
-    index = deltaY.index;
-    currentX += deltaX.value;
-    currentY += deltaY.value;
-    if (previousDistinctX === currentX && previousDistinctY === currentY) {
-      continue;
-    }
-    previousDistinctX = currentX;
-    previousDistinctY = currentY;
-    childCount += 1;
-    if (currentX < minX) minX = currentX;
-    else if (currentX > maxX) maxX = currentX;
-    if (currentY < minY) minY = currentY;
-    else if (currentY > maxY) maxY = currentY;
-  }
-
-  return {
-    childCount,
-    localBounds: { minX, minY, maxX, maxY },
-    lastPoint: { x: currentX, y: currentY },
-  };
-}
-
-/**
- * @param {string | undefined} d
- * @returns {{childCount: number, localBounds: {minX: number, minY: number, maxX: number, maxY: number} | null}}
- */
-function scanPathSummary(d) {
-  const scanned = scanPersistedPencilPath(d);
-  return {
-    childCount: scanned.childCount,
-    localBounds: scanned.localBounds,
-  };
-}
-
-/**
- * @param {string | undefined} d
- * @param {{x: number, y: number}[]} points
- * @returns {string}
- */
-function appendPersistedPencilPath(d, points) {
-  if (!Array.isArray(points) || points.length === 0) {
-    return typeof d === "string" ? d : "";
-  }
-  const scanned = scanPersistedPencilPath(d);
-  if (!scanned.lastPoint) return "";
-  let lastX = scanned.lastPoint.x;
-  let lastY = scanned.lastPoint.y;
-  let pathData = d || "";
-  for (let index = 0; index < points.length; index += 1) {
-    const point = points[index];
-    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
-      continue;
-    }
-    const x = roundPathValue(point.x);
-    const y = roundPathValue(point.y);
-    pathData += ` l ${x - lastX} ${y - lastY}`;
-    lastX = x;
-    lastY = y;
-  }
-  return pathData;
-}
-
-/**
- * @param {{x: number, y: number}[]} points
- * @returns {string}
- */
-function renderPencilPath(points) {
-  if (!Array.isArray(points) || points.length === 0) return "";
-  const firstPoint = points[0];
-  if (
-    !firstPoint ||
-    !Number.isFinite(firstPoint.x) ||
-    !Number.isFinite(firstPoint.y)
-  ) {
-    return "";
-  }
-  let lastX = roundPathValue(firstPoint.x);
-  let lastY = roundPathValue(firstPoint.y);
-  let pathData = `M ${lastX} ${lastY}`;
-  if (points.length === 1) return `${pathData} l 0 0`;
-  for (let index = 1; index < points.length; index += 1) {
-    const point = points[index];
-    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
-      continue;
-    }
-    const x = roundPathValue(point.x);
-    const y = roundPathValue(point.y);
-    pathData += ` l ${x - lastX} ${y - lastY}`;
-    lastX = x;
-    lastY = y;
-  }
-  return pathData;
-}
-
-/**
- * @param {StoredPencilPathItem} item
- * @param {string} pathData
- * @param {StoredPencilPathSerializeHelpers} helpers
- * @returns {string}
- */
-function serializeStoredPencilPath(item, pathData, helpers) {
-  if (!pathData) return "";
-  const transform = helpers.renderTransformAttribute(item.transform);
-  const id = typeof item.id === "string" ? helpers.escapeHtml(item.id) : "";
-  const color = helpers.escapeHtml(item.color || "#000000");
-  const size = helpers.numberOrZero(item.size) | 0;
-  const opacity =
-    typeof item.opacity === "number" ? ` opacity="${item.opacity}"` : "";
-  return (
-    `<path id="${id}" d="${helpers.escapeHtml(pathData)}"` +
-    ` stroke="${color}" stroke-width="${size}" fill="none" stroke-linecap="round" stroke-linejoin="round"${opacity}${transform}></path>`
-  );
-}
-
 export {
   appendPersistedPencilPath,
   renderPencilPath,
@@ -287,57 +80,7 @@ export const toolId = "pencil";
 const toolCode = TOOL_CODE_BY_ID[toolId];
 export const drawsOnBoard = true;
 
-/** @type {import("../shape_contract.js").ToolContract} */
-const contract = {
-  toolId,
-  toolCode,
-  payloadKind: "children",
-  storedTagName: "path",
-  liveMessageFields: /** @type {const} */ ({
-    [MutationType.CREATE]: {
-      id: "id",
-      color: "color",
-      size: "size",
-      opacity: "opacity?",
-    },
-    [MutationType.APPEND]: {
-      parent: "id",
-      x: "coord",
-      y: "coord",
-    },
-  }),
-  summarizeStoredSvgItem(entry, paintOrder, helpers) {
-    const size = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "stroke-width"),
-    );
-    const scanned = scanPathSummary(helpers.readStoredSvgAttribute(entry, "d"));
-    if (size === undefined || scanned.childCount === 0) return null;
-    return {
-      id: helpers.id,
-      tool: contract.toolId,
-      data: helpers.decorateStoredItemData(
-        {
-          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
-          size,
-        },
-        helpers.opacity,
-        helpers.transform,
-      ),
-      childCount: scanned.childCount,
-      paintOrder,
-      localBounds: scanned.localBounds,
-    };
-  },
-  serializeStoredSvgItem(item, helpers) {
-    const points = Array.isArray(item._children) ? item._children : [];
-    const pathData = renderPencilPath(points);
-    return serializeStoredPencilPath(item, pathData, helpers);
-  },
-  renderBoardSvg(pencil, helpers) {
-    const pathstring = renderPencilPath(pencil._children || []);
-    return helpers.renderPath(pencil, pathstring);
-  },
-};
+const contract = PencilContract;
 
 export { contract };
 export const shortcut = "p";

--- a/client-data/tools/pencil/pencil_path.js
+++ b/client-data/tools/pencil/pencil_path.js
@@ -1,0 +1,212 @@
+/**
+ * DOM-free helpers for the canonical persisted pencil path format
+ * (`M <x> <y> l <dx> <dy> ...`). Shared by the pencil runtime, the storage
+ * contract, and server persistence so none of them need the browser tool graph.
+ */
+
+/** @typedef {import("../shape_contract.js").SvgTransform} StoredPencilTransform */
+/** @typedef {{id?: string, color?: string, size?: number, opacity?: number, transform?: StoredPencilTransform}} StoredPencilPathItem */
+/** @typedef {{escapeHtml: (value: string) => string, numberOrZero: (value: unknown) => number, renderTransformAttribute: (transform: StoredPencilTransform | undefined) => string}} StoredPencilPathSerializeHelpers */
+
+/**
+ * @param {number} value
+ * @returns {number}
+ */
+function roundPathValue(value) {
+  return Math.round(value);
+}
+
+/**
+ * @param {string} d
+ * @param {number} index
+ * @returns {{value: number, index: number} | null}
+ */
+function readCanonicalPathInteger(d, index) {
+  const length = d.length;
+  let next = index;
+  let sign = 1;
+  if (next < length && d.charCodeAt(next) === 45) {
+    sign = -1;
+    next += 1;
+  }
+  if (next >= length) return null;
+  let code = d.charCodeAt(next) - 48;
+  if (code < 0 || code > 9) return null;
+  let value = 0;
+  while (next < length && code >= 0 && code <= 9) {
+    value = value * 10 + code;
+    next += 1;
+    if (next >= length) break;
+    code = d.charCodeAt(next) - 48;
+  }
+  return { value: sign * value, index: next };
+}
+
+const EMPTY_PERSISTED_PENCIL_SCAN = {
+  childCount: 0,
+  localBounds: null,
+  lastPoint: null,
+};
+
+/**
+ * @param {string | undefined} d
+ * @returns {{
+ *   childCount: number,
+ *   localBounds: {minX: number, minY: number, maxX: number, maxY: number} | null,
+ *   lastPoint: {x: number, y: number} | null,
+ * }}
+ */
+export function scanPersistedPencilPath(d) {
+  if (typeof d !== "string" || d === "") return EMPTY_PERSISTED_PENCIL_SCAN;
+  const length = d.length;
+  if (length < 5 || d.charCodeAt(0) !== 77 || d.charCodeAt(1) !== 32)
+    return EMPTY_PERSISTED_PENCIL_SCAN;
+
+  let index = 2;
+  const firstX = readCanonicalPathInteger(d, index);
+  if (!firstX || firstX.index >= length || d.charCodeAt(firstX.index) !== 32)
+    return EMPTY_PERSISTED_PENCIL_SCAN;
+  index = firstX.index + 1;
+  const firstY = readCanonicalPathInteger(d, index);
+  if (!firstY) return EMPTY_PERSISTED_PENCIL_SCAN;
+  index = firstY.index;
+
+  let currentX = firstX.value;
+  let currentY = firstY.value;
+  let minX = currentX;
+  let minY = currentY;
+  let maxX = currentX;
+  let maxY = currentY;
+  let childCount = 1;
+  let previousDistinctX = currentX;
+  let previousDistinctY = currentY;
+
+  while (index < length) {
+    if (
+      index + 2 >= length ||
+      d.charCodeAt(index) !== 32 ||
+      d.charCodeAt(index + 1) !== 108 ||
+      d.charCodeAt(index + 2) !== 32
+    ) {
+      return EMPTY_PERSISTED_PENCIL_SCAN;
+    }
+    index += 3;
+    const deltaX = readCanonicalPathInteger(d, index);
+    if (!deltaX || deltaX.index >= length || d.charCodeAt(deltaX.index) !== 32)
+      return EMPTY_PERSISTED_PENCIL_SCAN;
+    index = deltaX.index + 1;
+    const deltaY = readCanonicalPathInteger(d, index);
+    if (!deltaY) return EMPTY_PERSISTED_PENCIL_SCAN;
+    index = deltaY.index;
+    currentX += deltaX.value;
+    currentY += deltaY.value;
+    if (previousDistinctX === currentX && previousDistinctY === currentY) {
+      continue;
+    }
+    previousDistinctX = currentX;
+    previousDistinctY = currentY;
+    childCount += 1;
+    if (currentX < minX) minX = currentX;
+    else if (currentX > maxX) maxX = currentX;
+    if (currentY < minY) minY = currentY;
+    else if (currentY > maxY) maxY = currentY;
+  }
+
+  return {
+    childCount,
+    localBounds: { minX, minY, maxX, maxY },
+    lastPoint: { x: currentX, y: currentY },
+  };
+}
+
+/**
+ * @param {string | undefined} d
+ * @returns {{childCount: number, localBounds: {minX: number, minY: number, maxX: number, maxY: number} | null}}
+ */
+export function scanPathSummary(d) {
+  const scanned = scanPersistedPencilPath(d);
+  return {
+    childCount: scanned.childCount,
+    localBounds: scanned.localBounds,
+  };
+}
+
+/**
+ * @param {string | undefined} d
+ * @param {{x: number, y: number}[]} points
+ * @returns {string}
+ */
+export function appendPersistedPencilPath(d, points) {
+  if (!Array.isArray(points) || points.length === 0) {
+    return typeof d === "string" ? d : "";
+  }
+  const scanned = scanPersistedPencilPath(d);
+  if (!scanned.lastPoint) return "";
+  let lastX = scanned.lastPoint.x;
+  let lastY = scanned.lastPoint.y;
+  let pathData = d || "";
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index];
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+      continue;
+    }
+    const x = roundPathValue(point.x);
+    const y = roundPathValue(point.y);
+    pathData += ` l ${x - lastX} ${y - lastY}`;
+    lastX = x;
+    lastY = y;
+  }
+  return pathData;
+}
+
+/**
+ * @param {{x: number, y: number}[]} points
+ * @returns {string}
+ */
+export function renderPencilPath(points) {
+  if (!Array.isArray(points) || points.length === 0) return "";
+  const firstPoint = points[0];
+  if (
+    !firstPoint ||
+    !Number.isFinite(firstPoint.x) ||
+    !Number.isFinite(firstPoint.y)
+  ) {
+    return "";
+  }
+  let lastX = roundPathValue(firstPoint.x);
+  let lastY = roundPathValue(firstPoint.y);
+  let pathData = `M ${lastX} ${lastY}`;
+  if (points.length === 1) return `${pathData} l 0 0`;
+  for (let index = 1; index < points.length; index += 1) {
+    const point = points[index];
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+      continue;
+    }
+    const x = roundPathValue(point.x);
+    const y = roundPathValue(point.y);
+    pathData += ` l ${x - lastX} ${y - lastY}`;
+    lastX = x;
+    lastY = y;
+  }
+  return pathData;
+}
+
+/**
+ * @param {StoredPencilPathItem} item
+ * @param {string} pathData
+ * @param {StoredPencilPathSerializeHelpers} helpers
+ * @returns {string}
+ */
+export function serializeStoredPencilPath(item, pathData, helpers) {
+  if (!pathData) return "";
+  const transform = helpers.renderTransformAttribute(item.transform);
+  const id = typeof item.id === "string" ? helpers.escapeHtml(item.id) : "";
+  const color = helpers.escapeHtml(item.color || "#000000");
+  const size = helpers.numberOrZero(item.size) | 0;
+  const opacity =
+    typeof item.opacity === "number" ? ` opacity="${item.opacity}"` : "";
+  return (
+    `<path id="${id}" d="${helpers.escapeHtml(pathData)}"` +
+    ` stroke="${color}" stroke-width="${size}" fill="none" stroke-linecap="round" stroke-linejoin="round"${opacity}${transform}></path>`
+  );
+}

--- a/client-data/tools/rectangle/index.js
+++ b/client-data/tools/rectangle/index.js
@@ -1,10 +1,10 @@
+import { RectangleContract } from "../contracts.js";
 import {
   constrainEqualSpanToBoard,
   createShapeToolBoot,
   makeBoxShapeUpdateMessage,
   makeSeedShapeCreateMessage,
 } from "../shape_tool.js";
-import { TOOL_CODE_BY_ID } from "../tool-order.js";
 
 export {
   cancelShapeToolTouchGesture as cancelTouchGesture,
@@ -14,100 +14,11 @@ export {
   releaseShapeTool as release,
 } from "../shape_tool.js";
 
-import {
-  defineShapeContract,
-  normalizeRectBounds,
-  serializeStoredShapeTag,
-  summarizeStoredShape,
-} from "../shape_contract.js";
-
 export const toolId = "rectangle";
-const toolCode = TOOL_CODE_BY_ID[toolId];
 export const drawsOnBoard = true;
 export const mouseCursor = "crosshair";
 
-const contract = defineShapeContract({
-  toolId,
-  toolCode,
-  storedTagName: "rect",
-  updatableFields: /** @type {const} */ (["x", "y", "x2", "y2"]),
-  summarizeStoredSvgItem(entry, paintOrder, helpers) {
-    const x = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x"));
-    const y = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y"));
-    const width = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "width"),
-    );
-    const height = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "height"),
-    );
-    const size = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "stroke-width"),
-    );
-    if (
-      x === undefined ||
-      y === undefined ||
-      width === undefined ||
-      height === undefined ||
-      size === undefined
-    ) {
-      return null;
-    }
-    return summarizeStoredShape(
-      {
-        id: helpers.id,
-        tool: toolId,
-        paintOrder,
-        data: {
-          x,
-          y,
-          x2: x + width,
-          y2: y + height,
-          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
-          size,
-        },
-        localBounds: {
-          minX: x,
-          minY: y,
-          maxX: x + width,
-          maxY: y + height,
-        },
-      },
-      helpers.opacity,
-      helpers.transform,
-      helpers.decorateStoredItemData,
-    );
-  },
-  serializeStoredSvgItem(item, helpers) {
-    const bounds = normalizeRectBounds(
-      helpers.numberOrZero(item.x),
-      helpers.numberOrZero(item.y),
-      helpers.numberOrZero(item.x2),
-      helpers.numberOrZero(item.y2),
-    );
-    return serializeStoredShapeTag(
-      "rect",
-      ` x="${bounds.x}" y="${bounds.y}" width="${bounds.width}" height="${bounds.height}"`,
-      item,
-      helpers,
-    );
-  },
-  renderBoardSvg(shape, helpers) {
-    const bounds = normalizeRectBounds(
-      helpers.numberOrZero(shape.x),
-      helpers.numberOrZero(shape.y),
-      helpers.numberOrZero(shape.x2),
-      helpers.numberOrZero(shape.y2),
-    );
-    return (
-      "<rect " +
-      (shape.id ? `id="${helpers.htmlspecialchars(shape.id)}" ` : "") +
-      `x="${bounds.x}" y="${bounds.y}" width="${bounds.width}" height="${bounds.height}" ` +
-      `stroke="${helpers.htmlspecialchars(shape.color || "#000")}" stroke-width="${helpers.numberOrZero(shape.size) | 0}" ` +
-      helpers.renderTranslate(shape) +
-      "/>"
-    );
-  },
-});
+const contract = RectangleContract;
 
 /** @typedef {import("../shape_tool.js").ShapeCreateMessage<typeof contract.toolCode>} RectangleCreateMessage */
 /** @typedef {import("../shape_tool.js").ShapeBoxUpdateMessage<typeof contract.toolCode>} RectangleUpdateMessage */

--- a/client-data/tools/straight-line/index.js
+++ b/client-data/tools/straight-line/index.js
@@ -1,9 +1,9 @@
+import { StraightLineContract } from "../contracts.js";
 import {
   createShapeToolBoot,
   makeLineShapeUpdateMessage,
   makeSeedShapeCreateMessage,
 } from "../shape_tool.js";
-import { TOOL_CODE_BY_ID } from "../tool-order.js";
 
 export {
   cancelShapeToolTouchGesture as cancelTouchGesture,
@@ -13,80 +13,11 @@ export {
   releaseShapeTool as release,
 } from "../shape_tool.js";
 
-import {
-  defineShapeContract,
-  serializeStoredShapeTag,
-  summarizeStoredShape,
-} from "../shape_contract.js";
-
 export const toolId = "straight-line";
-const toolCode = TOOL_CODE_BY_ID[toolId];
 export const drawsOnBoard = true;
 export const mouseCursor = "crosshair";
 
-const contract = defineShapeContract({
-  toolId,
-  toolCode,
-  storedTagName: "line",
-  updatableFields: /** @type {const} */ (["x2", "y2"]),
-  summarizeStoredSvgItem(entry, paintOrder, helpers) {
-    const x1 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x1"));
-    const y1 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y1"));
-    const x2 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x2"));
-    const y2 = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y2"));
-    const size = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "stroke-width"),
-    );
-    if (
-      x1 === undefined ||
-      y1 === undefined ||
-      x2 === undefined ||
-      y2 === undefined ||
-      size === undefined
-    ) {
-      return null;
-    }
-    return summarizeStoredShape(
-      {
-        id: helpers.id,
-        tool: toolId,
-        paintOrder,
-        data: {
-          x: x1,
-          y: y1,
-          x2,
-          y2,
-          color: helpers.readStoredSvgAttribute(entry, "stroke") || "#000000",
-          size,
-        },
-        localBounds: {
-          minX: Math.min(x1, x2),
-          minY: Math.min(y1, y2),
-          maxX: Math.max(x1, x2),
-          maxY: Math.max(y1, y2),
-        },
-      },
-      helpers.opacity,
-      helpers.transform,
-      helpers.decorateStoredItemData,
-    );
-  },
-  serializeStoredSvgItem(item, helpers) {
-    return serializeStoredShapeTag(
-      "line",
-      ` x1="${helpers.numberOrZero(item.x)}" y1="${helpers.numberOrZero(item.y)}"` +
-        ` x2="${helpers.numberOrZero(item.x2)}" y2="${helpers.numberOrZero(item.y2)}"`,
-      item,
-      helpers,
-    );
-  },
-  renderBoardSvg(shape, helpers) {
-    return helpers.renderPath(
-      shape,
-      `M${shape.x} ${shape.y}L${shape.x2} ${shape.y2}`,
-    );
-  },
-});
+const contract = StraightLineContract;
 
 /** @typedef {import("../shape_tool.js").ShapeCreateMessage<typeof contract.toolCode>} StraightLineCreateMessage */
 /** @typedef {import("../shape_tool.js").ShapeLineUpdateMessage<typeof contract.toolCode>} StraightLineUpdateMessage */

--- a/client-data/tools/text/index.js
+++ b/client-data/tools/text/index.js
@@ -28,11 +28,11 @@ import { VIEWPORT_LAYOUT_EVENT } from "../../js/board_viewport.js";
 import { logFrontendEvent } from "../../js/frontend_logging.js";
 import {
   clampSize,
-  getLocalGeometryBounds,
   resolveMaxBoardSize,
   truncateText,
 } from "../../js/message_common.js";
 import { MutationType } from "../../js/mutation_type.js";
+import { TextContract } from "../contracts.js";
 import { TOOL_CODE_BY_ID } from "../tool-order.js";
 
 /** @import { ToolBootContext, ToolRuntimeModules } from "../../../types/app-runtime" */
@@ -138,109 +138,7 @@ function isTextMessage(data) {
   );
 }
 
-/** @type {import("../shape_contract.js").ToolContract} */
-const contract = {
-  toolId,
-  toolCode,
-  payloadKind: "text",
-  storedTagName: "text",
-  updatableFields: /** @type {const} */ (["txt"]),
-  liveMessageFields: /** @type {const} */ ({
-    [MutationType.CREATE]: {
-      id: "id",
-      color: "color",
-      size: "size",
-      opacity: "opacity?",
-      x: "coord",
-      y: "coord",
-    },
-    [MutationType.UPDATE]: {
-      id: "id",
-      txt: "text",
-    },
-  }),
-  summarizeStoredSvgItem(entry, paintOrder, helpers) {
-    const x = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "x"));
-    const y = helpers.parseNumber(helpers.readStoredSvgAttribute(entry, "y"));
-    const size = helpers.parseNumber(
-      helpers.readStoredSvgAttribute(entry, "font-size"),
-    );
-    if (x === undefined || y === undefined || size === undefined) {
-      return null;
-    }
-    const textLength = helpers.decodedTextLength(entry.content || "");
-    return {
-      id: helpers.id,
-      tool: contract.toolId,
-      paintOrder,
-      data: helpers.decorateStoredItemData(
-        {
-          x,
-          y,
-          size,
-          color: helpers.readStoredSvgAttribute(entry, "fill") || "#000000",
-        },
-        helpers.opacity,
-        helpers.transform,
-      ),
-      textLength,
-      localBounds: getLocalGeometryBounds({
-        tool: toolId,
-        x,
-        y,
-        size,
-        textLength,
-      }),
-    };
-  },
-  parseStoredSvgItem(summary, entry, helpers) {
-    return {
-      id: summary.id,
-      tool: contract.toolId,
-      ...summary.data,
-      txt: helpers.unescapeHtml(entry.content || ""),
-    };
-  },
-  serializeStoredSvgItem(item, helpers) {
-    const transform = helpers.renderTransformAttribute(item.transform);
-    const id = typeof item.id === "string" ? helpers.escapeHtml(item.id) : "";
-    const color = helpers.escapeHtml(item.color || "#000000");
-    const opacity =
-      typeof item.opacity === "number" ? ` opacity="${item.opacity}"` : "";
-    const textValue = String(item.txt || "");
-    return (
-      `<text id="${id}" x="${helpers.numberOrZero(item.x)}" y="${helpers.numberOrZero(item.y)}"` +
-      ` font-size="${helpers.numberOrZero(item.size) | 0}" fill="${color}"${opacity}${transform}>` +
-      `${helpers.escapeHtml(textValue)}</text>`
-    );
-  },
-  renderBoardSvg(text, helpers) {
-    const x = helpers.numberOrZero(text.x);
-    const y = helpers.numberOrZero(text.y);
-    return (
-      "<text " +
-      'id="' +
-      helpers.htmlspecialchars(text.id || "t") +
-      '" ' +
-      'x="' +
-      (x | 0) +
-      '" ' +
-      'y="' +
-      (y | 0) +
-      '" ' +
-      'font-size="' +
-      (helpers.numberOrZero(text.size) | 0) +
-      '" ' +
-      'fill="' +
-      helpers.htmlspecialchars(text.color || "#000") +
-      '" ' +
-      helpers.renderTranslate(text) +
-      ">" +
-      helpers.htmlspecialchars(text.txt || "") +
-      "</text>"
-    );
-  },
-};
+const contract = TextContract;
 
 export { contract };
 export const shortcut = "t";

--- a/server/board/canonical_items.mjs
+++ b/server/board/canonical_items.mjs
@@ -1,5 +1,5 @@
 import MessageCommon from "../../client-data/js/message_common.js";
-import { TOOL_BY_ID } from "../../client-data/tools/index.js";
+import { TOOL_CONTRACT_BY_ID as TOOL_BY_ID } from "../../client-data/tools/contracts.js";
 import { summarizeStoredSvgItem } from "../persistence/stored_svg_item_codec.mjs";
 
 /**

--- a/server/persistence/stored_svg_item_codec.mjs
+++ b/server/persistence/stored_svg_item_codec.mjs
@@ -1,11 +1,9 @@
 import {
-  TOOL_BY_ID,
-  TOOL_BY_STORED_TAG_NAME,
-} from "../../client-data/tools/index.js";
-import {
   renderPencilPath,
   scanPathSummary,
-} from "../../client-data/tools/pencil/index.js";
+  TOOL_CONTRACT_BY_ID as TOOL_BY_ID,
+  TOOL_CONTRACT_BY_STORED_TAG_NAME as TOOL_BY_STORED_TAG_NAME,
+} from "../../client-data/tools/contracts.js";
 import { readRawAttribute } from "./svg_envelope.mjs";
 import { decodedTextLength, escapeHtml, unescapeHtml } from "./xml_escape.mjs";
 

--- a/server/persistence/svg_board_store.mjs
+++ b/server/persistence/svg_board_store.mjs
@@ -7,7 +7,7 @@ import {
   appendPersistedPencilPath,
   renderPencilPath,
   serializeStoredPencilPath,
-} from "../../client-data/tools/pencil/index.js";
+} from "../../client-data/tools/pencil/pencil_path.js";
 import {
   canonicalItemFromStoredSvgEntry,
   currentText,

--- a/server/socket/message_validation.mjs
+++ b/server/socket/message_validation.mjs
@@ -3,7 +3,11 @@ import {
   getMutationType,
   MutationType,
 } from "../../client-data/js/message_tool_metadata.js";
-import { Cursor, TOOLS } from "../../client-data/tools/index.js";
+import {
+  Cursor,
+  TOOL_CONTRACTS as TOOLS,
+  TOOL_ID_BY_CODE,
+} from "../../client-data/tools/contracts.js";
 
 /** @typedef {{[key: string]: unknown}} RawRecord */
 /** @typedef {Pick<import("../../types/server-runtime.d.ts").ServerConfig, "MAX_BOARD_SIZE" | "MAX_CHILDREN">} MessageValidationConfig */
@@ -36,7 +40,6 @@ import { Cursor, TOOLS } from "../../client-data/tools/index.js";
 /** @typedef {import("../../client-data/tools/shape_contract.js").ToolContract} ToolContract */
 /** @typedef {"id" | "coord" | "color" | "size" | "opacity" | "text" | "transform" | "time"} SchemaFieldType */
 
-const MAX_TOOL_CODE = TOOLS.length;
 const SHAPE_CONTRACTS = TOOLS.filter((tool) => tool.shapeTool === true);
 const SHAPE_CREATE_FIELDS = {
   id: "id",
@@ -114,8 +117,7 @@ function literal(expected) {
 function normalizeLiveToolCode(value) {
   return typeof value === "number" &&
     Number.isSafeInteger(value) &&
-    value >= 1 &&
-    value <= MAX_TOOL_CODE
+    Object.prototype.hasOwnProperty.call(TOOL_ID_BY_CODE, value)
     ? accepted(/** @type {ToolCode} */ (value))
     : rejected("invalid tool");
 }

--- a/test-node/boot_graph.test.js
+++ b/test-node/boot_graph.test.js
@@ -87,6 +87,25 @@ test("pan-ready boot graph excludes full app and tool implementations", () => {
   );
 });
 
+test("server tool contracts stay independent from tool interaction modules", () => {
+  for (const entry of [
+    "client-data/tools/contracts.js",
+    "server/socket/message_validation.mjs",
+    "server/persistence/stored_svg_item_codec.mjs",
+    "server/board/canonical_items.mjs",
+  ]) {
+    const closure = staticImportClosure(entry);
+    assertClosureExcludes(closure, ["client-data/tools/index.js"]);
+    assert.equal(
+      Array.from(closure).some((file) =>
+        /^client-data\/tools\/[^/]+\/index\.js$/.test(file),
+      ),
+      false,
+      entry,
+    );
+  }
+});
+
 test("client tool metadata stays independent from tool implementations", () => {
   for (const entry of [
     "client-data/js/message_tool_metadata.js",

--- a/test-node/tool_contract_drift.test.js
+++ b/test-node/tool_contract_drift.test.js
@@ -1,0 +1,149 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const CONTRACTS_PATH = "../client-data/tools/contracts.js";
+const MANIFEST_PATH = "../client-data/tools/manifest.js";
+const INDEX_PATH = "../client-data/tools/index.js";
+
+/**
+ * @template T
+ * @param {Promise<T>} value
+ * @returns {Promise<T>}
+ */
+function load(value) {
+  return value;
+}
+
+test("wire tool codes match the documented protocol", async () => {
+  const { TOOL_CODE_BY_ID } = await load(import(MANIFEST_PATH));
+  assert.deepEqual(TOOL_CODE_BY_ID, {
+    pencil: 1,
+    "straight-line": 2,
+    rectangle: 3,
+    ellipse: 4,
+    text: 5,
+    eraser: 6,
+    hand: 7,
+    grid: 8,
+    download: 9,
+    zoom: 10,
+    clear: 11,
+    cursor: 12,
+  });
+});
+
+test("mutation type codes match the documented protocol", async () => {
+  const { MutationType } = await load(
+    import("../client-data/js/mutation_type.js"),
+  );
+  assert.deepEqual(
+    {
+      CREATE: MutationType.CREATE,
+      UPDATE: MutationType.UPDATE,
+      DELETE: MutationType.DELETE,
+      APPEND: MutationType.APPEND,
+      BATCH: MutationType.BATCH,
+      CLEAR: MutationType.CLEAR,
+      COPY: MutationType.COPY,
+    },
+    {
+      CREATE: 1,
+      UPDATE: 2,
+      DELETE: 3,
+      APPEND: 4,
+      BATCH: 5,
+      CLEAR: 6,
+      COPY: 7,
+    },
+  );
+});
+
+test("code-to-tool maps round trip through the explicit maps", async () => {
+  const { TOOL_CODE_BY_ID, TOOL_ID_BY_CODE } = await load(
+    import(MANIFEST_PATH),
+  );
+  for (const [toolId, code] of Object.entries(TOOL_CODE_BY_ID)) {
+    assert.equal(TOOL_ID_BY_CODE[code], toolId, `code ${code} -> ${toolId}`);
+  }
+  for (const [code, toolId] of Object.entries(TOOL_ID_BY_CODE)) {
+    assert.equal(
+      TOOL_CODE_BY_ID[toolId],
+      Number(code),
+      `${toolId} -> code ${code}`,
+    );
+  }
+});
+
+test("server-safe contracts agree with the manifest for every tool", async () => {
+  const { TOOL_CONTRACT_BY_ID } = await load(import(CONTRACTS_PATH));
+  const { TOOL_BY_ID } = await load(import(MANIFEST_PATH));
+  for (const [toolId, manifestEntry] of Object.entries(TOOL_BY_ID)) {
+    const contract = TOOL_CONTRACT_BY_ID[toolId];
+    assert.ok(contract, `missing contract for ${toolId}`);
+    assert.equal(contract.id, manifestEntry.id, `${toolId} id`);
+    assert.equal(contract.toolId, manifestEntry.toolId, `${toolId} toolId`);
+    assert.equal(
+      contract.storedTagName,
+      manifestEntry.storedTagName,
+      `${toolId} storedTagName`,
+    );
+    assert.equal(
+      contract.payloadKind,
+      manifestEntry.payloadKind,
+      `${toolId} payloadKind`,
+    );
+    assert.deepEqual(
+      contract.updatableFields,
+      manifestEntry.updatableFields,
+      `${toolId} updatableFields`,
+    );
+    assert.equal(
+      contract.requiredCapability,
+      manifestEntry.requiredCapability,
+      `${toolId} requiredCapability`,
+    );
+  }
+});
+
+test("storage contracts expose serialize/summarize for every stored tool", async () => {
+  const { STORAGE_CONTRACT_BY_ID, TOOL_CONTRACT_BY_STORED_TAG_NAME } =
+    await load(import(CONTRACTS_PATH));
+  for (const [toolId, contract] of Object.entries(STORAGE_CONTRACT_BY_ID)) {
+    assert.equal(typeof contract.summarizeStoredSvgItem, "function", toolId);
+    assert.equal(typeof contract.serializeStoredSvgItem, "function", toolId);
+    assert.ok(
+      typeof contract.storedTagName === "string",
+      `${toolId} storedTagName`,
+    );
+    assert.equal(
+      TOOL_CONTRACT_BY_STORED_TAG_NAME[contract.storedTagName].toolId,
+      toolId,
+      `${toolId} tag round trip`,
+    );
+  }
+});
+
+test("the runtime browser registry and the server contracts share metadata", async () => {
+  const { TOOL_BY_ID: RUNTIME_BY_ID } = await load(import(INDEX_PATH));
+  const { TOOL_CONTRACT_BY_ID } = await load(import(CONTRACTS_PATH));
+  for (const [toolId, contract] of Object.entries(TOOL_CONTRACT_BY_ID)) {
+    const runtime = RUNTIME_BY_ID[toolId];
+    assert.ok(runtime, `runtime missing ${toolId}`);
+    assert.equal(runtime.id, contract.id, `${toolId} id`);
+    assert.equal(
+      runtime.storedTagName,
+      contract.storedTagName,
+      `${toolId} storedTagName`,
+    );
+    assert.equal(
+      runtime.payloadKind,
+      contract.payloadKind,
+      `${toolId} payloadKind`,
+    );
+    assert.equal(
+      runtime.requiredCapability,
+      contract.requiredCapability,
+      `${toolId} requiredCapability`,
+    );
+  }
+});


### PR DESCRIPTION
Updates the LAQA entry for [`dd.discovered_processes`](https://github.com/DataDog/dd-source/blob/ophir.lojkine/DSCVR-453-caniche-discovery-process/domains/logs/apps/apis/logs-advanced-query-api/shared/libs/schema/generate/manual_tables.go#L638-L676) and the matching [dataset registry entry](https://github.com/DataDog/dd-source/blob/ophir.lojkine/DSCVR-453-caniche-discovery-process/domains/odp/shared/libs/dataset-registry/datasets/public/dd/dd.discovered_processes.dataset.yml) to match the new physical schema:

- `PhysicalName`: `service` -> `process`, `QualifiedPhysicalName`: `discovery.default.service` -> `discovery.default.process` (follows logs-backend#137183).
- `tags` column: drop `Expression: "CAST(host_tags AS HSTORE_CSV)"`. The physical column is now exposed natively as HSTORE_CSV (datadog/logs-backend#138138).
- Remove the `modified` column from both `manual_tables.go` and `dd.discovered_processes.dataset.yml`. It was a stray entry I introduced in #433002 that has never existed on the physical table — this is what the staging error `USER_ERROR: line 3:480: Column 'modified' cannot be resolved` is referring to.

Depends on both logs-backend PRs reaching us1.staging + us1.prod first.

Kill switch: existing LAQA feature flag `advanced-query.enable_discovered_processes_table`.

DSCVR-453

---

Verified end-to-end via Rapid Test Drive [`maserati-k5`](https://route-manager.us1.prod.dog/?dc=us1.staging.dog&facets=test_drive%255B%255D%3Dtrue%26handler_name%255B%255D%3Drapid-td-maserati-k5) (this branch deployed on staging). Sending a real DDSQL query that touches the renamed `tags` HSTORE column, against `dd.discovered_processes`, returns rows.

Request payload (`/tmp/ddsql_query.json`):

```json
{"data":{"type":"analysis_workspace_query_request","attributes":{
  "datasets":[
    {"data_source":"managed_resource","name":"src","table_name":"dd.discovered_processes"},
    {"data_source":"analysis_dataset","name":"result","query":{
      "type":"sql_analysis",
      "sql_query":"SELECT generated_service_name, host_name, tags->'region' AS region FROM src LIMIT 3"
    }}
  ],
  "query":{"dataset":"result","time_window":{"from":1779962250411,"to":1779965850411},"limit":3}
}}}
```

With the Test Drive header (this branch), 200 + rows:

```
$ dd-auth --domain dd.datad0g.com bash -c 'curl -sS \
    -H "DD-API-KEY: $DD_API_KEY" -H "DD-APPLICATION-KEY: $DD_APP_KEY" \
    -H "test-drive-maserati-k5: 1" -H "Content-Type: application/json" \
    --data-binary @/tmp/ddsql_query.json \
    "https://dd.datad0g.com/api/unstable/advanced/query/tabular"' \
    | jq '.data[0].attributes.columns'
[
  {"name":"generated_service_name","type":"string",
   "values":["emissary","spark","slap-controller-dev"]},
  {"name":"host_name","type":"string",
   "values":["i-08ec4fabc47fe69b3","i-0ba1faf7061313c18","ip-10-128-166-206.ec2.internal-gizmo"]},
  {"name":"region","type":"string",
   "values":["us-east-1","us-east-1","us-east-1"]}
]
```

Without the Test Drive header, the same request hits the regular staging deployment and gets a 400 (`"An error has occurred in an upstream dataset"` at the LAQA boundary; the upstream trace shows `USER_ERROR: line 3:480: Column 'modified' cannot be resolved`).
