### PR TITLE
make the user status visible in the sidebar

### DIFF
--- a/client-data/board.css
+++ b/client-data/board.css
@@ -363,6 +363,10 @@ select {
   font-weight: 700;
 }
 
+.connected-user-row-readonly .connected-user-name {
+  font-style: italic;
+}
+
 .connected-user-main {
   min-width: 0;
 }

--- a/client-data/js/board_access_module.js
+++ b/client-data/js/board_access_module.js
@@ -1,4 +1,3 @@
-import { boardStateGrantsCapability } from "../tools/manifest.js";
 import { DEFAULT_BOARD_STATE } from "./board_page_state.js";
 
 /** @import { AppBoardState, AppToolsState } from "../../types/app-runtime" */
@@ -30,35 +29,31 @@ export class AccessModule {
   applyBoardState(boardState) {
     const Tools = this.getTools();
     this.boardState = boardState;
-    const registry = Tools.toolRegistry;
 
-    // Tools and the style palette follow the live edit capability, so a
-    // read-only user (including one banned on an otherwise writable board) never
-    // keeps tools they cannot use. Mirrors the server-rendered toolbar, which
-    // filters the same way via boardStateGrantsCapability.
+    // Hide editing affordances whenever the user cannot edit (a read-only board,
+    // or a banned user on a writable one). The drawing tools themselves are
+    // gated by shouldDisplayTool, which is capability-aware.
+    const hideEditingTools = !this.canEdit;
     const settings = document.getElementById("settings");
-    if (settings) settings.style.display = this.canEdit ? "" : "none";
+    if (settings) settings.style.display = hideEditingTools ? "none" : "";
 
-    Object.keys(registry.mounted || {}).forEach((toolName) => {
+    Object.keys(Tools.toolRegistry.mounted || {}).forEach((toolName) => {
       const toolElem = document.getElementById(`toolID-${toolName}`);
       if (!toolElem) return;
-      const granted = boardStateGrantsCapability(
-        boardState,
-        registry.mounted[toolName]?.requiredCapability,
-      );
-      toolElem.style.display =
-        granted && registry.shouldDisplayTool(toolName) ? "" : "none";
+      toolElem.style.display = Tools.toolRegistry.shouldDisplayTool(toolName)
+        ? ""
+        : "none";
     });
 
-    registry.syncDrawToolAvailability(true);
+    Tools.toolRegistry.syncDrawToolAvailability(true);
 
-    const current = registry.current;
     if (
-      current &&
-      registry.mounted.hand &&
-      !boardStateGrantsCapability(boardState, current.requiredCapability)
+      hideEditingTools &&
+      Tools.toolRegistry.current &&
+      !Tools.toolRegistry.shouldDisplayTool(Tools.toolRegistry.current.name) &&
+      Tools.toolRegistry.mounted.hand
     ) {
-      registry.change("hand");
+      Tools.toolRegistry.change("hand");
     }
   }
 }

--- a/client-data/js/board_access_module.js
+++ b/client-data/js/board_access_module.js
@@ -1,3 +1,4 @@
+import { boardStateGrantsCapability } from "../tools/manifest.js";
 import { DEFAULT_BOARD_STATE } from "./board_page_state.js";
 
 /** @import { AppBoardState, AppToolsState } from "../../types/app-runtime" */
@@ -29,28 +30,35 @@ export class AccessModule {
   applyBoardState(boardState) {
     const Tools = this.getTools();
     this.boardState = boardState;
+    const registry = Tools.toolRegistry;
 
-    const hideEditingTools = this.readOnly && !this.canEdit;
+    // Tools and the style palette follow the live edit capability, so a
+    // read-only user (including one banned on an otherwise writable board) never
+    // keeps tools they cannot use. Mirrors the server-rendered toolbar, which
+    // filters the same way via boardStateGrantsCapability.
     const settings = document.getElementById("settings");
-    if (settings) settings.style.display = hideEditingTools ? "none" : "";
+    if (settings) settings.style.display = this.canEdit ? "" : "none";
 
-    Object.keys(Tools.toolRegistry.mounted || {}).forEach((toolName) => {
+    Object.keys(registry.mounted || {}).forEach((toolName) => {
       const toolElem = document.getElementById(`toolID-${toolName}`);
       if (!toolElem) return;
-      toolElem.style.display = Tools.toolRegistry.shouldDisplayTool(toolName)
-        ? ""
-        : "none";
+      const granted = boardStateGrantsCapability(
+        boardState,
+        registry.mounted[toolName]?.requiredCapability,
+      );
+      toolElem.style.display =
+        granted && registry.shouldDisplayTool(toolName) ? "" : "none";
     });
 
-    Tools.toolRegistry.syncDrawToolAvailability(true);
+    registry.syncDrawToolAvailability(true);
 
+    const current = registry.current;
     if (
-      hideEditingTools &&
-      Tools.toolRegistry.current &&
-      !Tools.toolRegistry.shouldDisplayTool(Tools.toolRegistry.current.name) &&
-      Tools.toolRegistry.mounted.hand
+      current &&
+      registry.mounted.hand &&
+      !boardStateGrantsCapability(boardState, current.requiredCapability)
     ) {
-      Tools.toolRegistry.change("hand");
+      registry.change("hand");
     }
   }
 }

--- a/client-data/js/board_presence_module.js
+++ b/client-data/js/board_presence_module.js
@@ -537,7 +537,11 @@ function updateConnectedUserRow(getTools, row, user) {
   const name = /** @type {HTMLElement | null} */ (
     row.querySelector(".connected-user-name")
   );
-  if (name) name.textContent = user.name;
+  if (name) {
+    name.textContent = user.canClear ? `\u{1F338} ${user.name}` : user.name;
+  }
+
+  row.classList.toggle("connected-user-row-readonly", user.canEdit === false);
 
   const meta = /** @type {HTMLElement | null} */ (
     row.querySelector(".connected-user-meta")

--- a/client-data/js/board_tool_registry_module.js
+++ b/client-data/js/board_tool_registry_module.js
@@ -1,4 +1,5 @@
 import {
+  boardStateGrantsCapability,
   getToolIconPath,
   getToolModuleImportPath,
   getToolStylesheetPath,
@@ -243,7 +244,14 @@ export class ToolRegistryModule {
 
   /** @param {string} toolName */
   shouldDisplayTool(toolName) {
-    return getToolButton(toolName) !== null;
+    if (getToolButton(toolName) === null) return false;
+    // A tool is only shown when the current board state grants its capability,
+    // mirroring the server's getVisibleTools. This keeps read-only users (e.g.
+    // banned ones) from seeing or activating tools they cannot use.
+    return boardStateGrantsCapability(
+      Tools.access.boardState,
+      TOOL_BY_ID[toolName]?.requiredCapability,
+    );
   }
 
   /** @param {string} toolName */

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,10 @@
         "socket.io": "^4"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.12",
-        "@playwright/test": "^1.59.1",
-        "@types/node": "^25.6.0",
-        "typescript": "^6.0.2"
+        "@biomejs/biome": "^2.5.0",
+        "@playwright/test": "^1.61.0",
+        "@types/node": "^25.9.3",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "url": "http://github.com/lovasoa/whitebophir.git"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.12",
-    "@playwright/test": "^1.59.1",
-    "@types/node": "^25.6.0",
-    "typescript": "^6.0.2"
+    "@biomejs/biome": "^2.5.0",
+    "@playwright/test": "^1.61.0",
+    "@types/node": "^25.9.3",
+    "typescript": "^6.0.3"
   }
 }

--- a/server/auth/board_capabilities.mjs
+++ b/server/auth/board_capabilities.mjs
@@ -14,6 +14,7 @@ import { isConfiguredModerator } from "./board_moderators.mjs";
 /** @typedef {{AUTH_SECRET_KEY: string, BOARD_MODERATORS?: Map<string, Set<string>>}} BoardCapabilityConfig */
 /** @typedef {{name: string, readonly?: boolean, isReadOnly?: () => boolean}} BoardCapabilityBoard */
 /** @typedef {{token?: string | null, userSecret?: string | null}} BoardCapabilityUserInfo */
+/** @typedef {() => boolean} IsBannedPredicate */
 /** @typedef {import("../../types/app-runtime").BoardCapabilities} BoardCapabilities */
 /** @typedef {import("../../types/app-runtime").BoardCapability} BoardCapability */
 /** @typedef {import("../../types/app-runtime").AppBoardState} RenderedBoardState */
@@ -73,7 +74,12 @@ function capabilitiesGrant(capabilities, capability) {
  * Creates a per-request/per-socket resolver so JWT verification happens once
  * for a board and the resulting compatibility role stays inside this module.
  *
- * @param {{config: BoardCapabilityConfig, boardName: string, userInfo?: BoardCapabilityUserInfo}} input
+ * `isBanned` is a live predicate (re-evaluated on every capability query) so a
+ * time-based edit ban degrades `canEdit` to `false` without a separate
+ * enforcement path. Moderators bypass it. Defaults to never-banned, which keeps
+ * ban-unaware callers (HTTP rendering) untouched.
+ *
+ * @param {{config: BoardCapabilityConfig, boardName: string, userInfo?: BoardCapabilityUserInfo, isBanned?: IsBannedPredicate}} input
  * @returns {{
  *   canOpen: () => boolean,
  *   canBan: () => boolean,
@@ -86,6 +92,7 @@ function capabilitiesGrant(capabilities, capability) {
 function forBoard(input) {
   const jwtEnabled = input.config.AUTH_SECRET_KEY !== "";
   const role = roleForBoard(input.config, input.boardName, input.userInfo);
+  const isBanned = input.isBanned || (() => false);
 
   function canOpen() {
     return !jwtEnabled || role !== "forbidden";
@@ -98,10 +105,11 @@ function forBoard(input) {
   function resolveCapabilities(board) {
     const readonly = isBoardReadOnly(board);
     const moderator = isClearCapableRole(role);
+    const banned = !moderator && isBanned();
     if (!jwtEnabled && !moderator) {
       return {
         canOpen: true,
-        canEdit: !readonly,
+        canEdit: !readonly && !banned,
         canClear: false,
       };
     }
@@ -109,7 +117,7 @@ function forBoard(input) {
     const open = canOpen();
     return {
       canOpen: open,
-      canEdit: open && (!readonly || isEditCapableRole(role)),
+      canEdit: open && !banned && (!readonly || isEditCapableRole(role)),
       canClear: moderator,
     };
   }

--- a/server/http/templating.mjs
+++ b/server/http/templating.mjs
@@ -13,7 +13,7 @@ import { parseRequestUrl } from "./request_url.mjs";
 
 /** @typedef {{[name: string]: string}} TranslationDictionary */
 /** @typedef {{[language: string]: TranslationDictionary}} TranslationMap */
-/** @typedef {{baseUrl: string, baseHref: string, languages: string[], language: string, translations: TranslationDictionary, configuration: object, moderator: boolean, htmlHeadSnippet: string, [name: string]: any}} TemplateParameters */
+/** @typedef {{baseUrl: string, baseHref: string, languages: string[], language: string, translations: TranslationDictionary, configuration: object, moderator: boolean, htmlHeadSnippet: string, varyCookie?: boolean, [name: string]: any}} TemplateParameters */
 /** @typedef {import("http").IncomingMessage} TemplateRequest */
 /** @typedef {import("http").ServerResponse} TemplateResponse */
 /** @typedef {string | string[] | undefined} HeaderValue */
@@ -211,6 +211,18 @@ function cacheControl(isDevelopment, prodValue) {
   return isDevelopment ? "no-store" : prodValue;
 }
 
+/**
+ * @param {URL} parsedUrl
+ * @param {TemplateParameters} parameters
+ * @returns {{Vary?: string}}
+ */
+function htmlVaryHeaders(parsedUrl, parameters) {
+  const vary = [];
+  if (!parsedUrl.searchParams.get("lang")) vary.push("Accept-Language");
+  if (parameters.varyCookie) vary.push("Cookie");
+  return vary.length === 0 ? {} : { Vary: vary.join(", ") };
+}
+
 const startHtmlResponse =
   /** @type {(response: TemplateResponse, request: TemplateRequest, parsedUrl: URL, parameters: TemplateParameters, cacheControlValue: string, contentLength?: number) => { stream: import("stream").Writable, encoding: import("./compression.mjs").CompressionEncoding | undefined }} */
   (
@@ -228,9 +240,7 @@ const startHtmlResponse =
       "Content-Type": "text/html",
       "Cache-Control": cacheControlValue,
       ...(typeof parameters.etag === "string" ? { ETag: parameters.etag } : {}),
-      ...(!parsedUrl.searchParams.get("lang")
-        ? { Vary: "Accept-Language" }
-        : {}),
+      ...htmlVaryHeaders(parsedUrl, parameters),
     });
 
 class StaticTemplate {

--- a/server/routes/board_http_helpers.mjs
+++ b/server/routes/board_http_helpers.mjs
@@ -16,6 +16,8 @@ import { pinReplayBaseline } from "../board/registry.mjs";
 import { badRequest } from "../http/boundary_errors.mjs";
 import { requestScheme } from "../http/observation.mjs";
 import { publicPath } from "../http/request_url.mjs";
+import { isEditBanned } from "../socket/bans.mjs";
+import { resolveRequestClientIpSafe } from "../socket/policy.mjs";
 
 /** @import { HttpRequest, HttpResponse, ObservedHttpRequest, ServerConfig } from "../../types/server-runtime.d.ts" */
 
@@ -190,13 +192,22 @@ function ensureBoardUserSecretCookie(request, response, parsedUrl) {
  * @returns {ReturnType<typeof BoardPermissions.forBoard>}
  */
 function boardPermissionsForRequest(ctx, boardName) {
+  const config = ctx.runtime.config;
+  const userSecret = getUserSecretFromCookieHeader(ctx.request.headers.cookie);
   return BoardPermissions.forBoard({
-    config: ctx.runtime.config,
+    config,
     boardName,
-    userInfo: {
-      token: ctx.url.searchParams.get("token"),
-      userSecret: getUserSecretFromCookieHeader(ctx.request.headers.cookie),
-    },
+    userInfo: { token: ctx.url.searchParams.get("token"), userSecret },
+    // Render the served board state ban-aware too, so a banned user's HTML
+    // (board-state script + toolbar) is read-only from first paint, matching
+    // the socket. Same live predicate the socket path injects.
+    isBanned: () =>
+      isEditBanned(
+        boardName,
+        userSecret,
+        resolveRequestClientIpSafe(config, ctx.request),
+        Date.now(),
+      ),
   });
 }
 

--- a/server/routes/board_page.mjs
+++ b/server/routes/board_page.mjs
@@ -135,7 +135,12 @@ async function serveLoadedBoardCacheHit(ctx, pageRequest) {
   const persistedSeq = loadedBoard.getPersistedSeq();
   if (!pageRequest.cachedSeqs.includes(persistedSeq)) return false;
 
-  respondWithBoardPageNotModified(ctx, pageRequest.boardName, persistedSeq);
+  respondWithBoardPageNotModified(
+    ctx,
+    pageRequest.boardName,
+    persistedSeq,
+    pageRequest.boardPermissions.boardState(loadedBoard),
+  );
   return true;
 }
 
@@ -189,10 +194,15 @@ function serveBoardDocumentCacheHit(ctx, pageRequest, document) {
   if (!matchesIfNoneMatch(ctx.request.headers["if-none-match"], etag)) {
     return false;
   }
+  const boardState = pageRequest.boardPermissions.boardState({
+    name: pageRequest.boardName,
+    readonly: document.metadata.readonly,
+  });
   respondWithBoardPageNotModified(
     ctx,
     pageRequest.boardName,
     document.metadata.seq || 0,
+    boardState,
     etag,
   );
   return true;
@@ -202,16 +212,50 @@ function serveBoardDocumentCacheHit(ctx, pageRequest, document) {
  * @param {HttpRouteContext} ctx
  * @param {string} boardName
  * @param {number} seq
+ * @param {AppBoardState} boardState
  * @param {string=} etag
  * @returns {void}
  */
-function respondWithBoardPageNotModified(ctx, boardName, seq, etag) {
+function respondWithBoardPageNotModified(
+  ctx,
+  boardName,
+  seq,
+  boardState,
+  etag,
+) {
   pinServedBoardBaseline(boardName, seq, ctx.runtime.config);
   ctx.response.writeHead(304, {
     "Cache-Control": ctx.runtime.boardTemplate.cacheControl(),
     ETag: etag || boardPageETag(seq),
+    Vary: boardHtmlVaryHeader(ctx.url, boardState),
   });
   ctx.response.end();
+}
+
+/**
+ * @param {AppBoardState} boardState
+ * @returns {boolean}
+ */
+function boardHtmlVariesByCookie(boardState) {
+  return (
+    boardState.readonly === true ||
+    boardState.canEdit !== true ||
+    boardState.canClear === true ||
+    boardState.canWrite !== true
+  );
+}
+
+/**
+ * @param {URL} parsedUrl
+ * @param {AppBoardState} boardState
+ * @returns {string}
+ */
+function boardHtmlVaryHeader(parsedUrl, boardState) {
+  const vary = [];
+  if (!parsedUrl.searchParams.get("lang")) vary.push("Accept-Language");
+  if (boardHtmlVariesByCookie(boardState)) vary.push("Cookie");
+  vary.push("Accept-Encoding");
+  return vary.join(", ");
 }
 
 /**
@@ -232,6 +276,7 @@ async function renderBoardDocument(ctx, pageRequest, document) {
   const renderOptions = {
     etag: boardPageETag(document.metadata.seq || 0),
     boardState,
+    varyCookie: boardHtmlVariesByCookie(boardState),
   };
 
   if (document.source === "svg" || document.source === "svg_backup") {

--- a/server/socket/broadcasts.mjs
+++ b/server/socket/broadcasts.mjs
@@ -8,18 +8,12 @@ import { SocketEvents } from "../../client-data/js/socket_events.js";
 import { Cursor } from "../../client-data/tools/index.js";
 import { getBoardSession } from "../board/session.mjs";
 import observability from "../observability/index.mjs";
-import { isEditBanned } from "./bans.mjs";
-import {
-  canApplyBoardMessage,
-  canBanOnBoard,
-  normalizeBroadcastData,
-} from "./policy.mjs";
+import { canApplyBoardMessage, normalizeBroadcastData } from "./policy.mjs";
 import { updateBoardUserFromMessage } from "./presence.mjs";
 import {
   enforceBroadcastPostNormalization,
   enforceBroadcastPreNormalization,
 } from "./rate_limits.mjs";
-import { getSocketUserSecret } from "./request.mjs";
 import { isTurnstileValidationActive } from "./turnstile.mjs";
 
 const { logger, metrics, tracing } = observability;
@@ -352,21 +346,6 @@ async function persistBoardBroadcast(
   }
   if (data.tool === Cursor.id) {
     finishSuccessfulEphemeralBoardWrite(socket, boardName, data, now, userName);
-    return;
-  }
-  if (
-    isEditBanned(boardName, getSocketUserSecret(socket), clientIp, now) &&
-    !canBanOnBoard(config, boardName, socket)
-  ) {
-    rejectBoardMessageWrite(
-      socket,
-      board,
-      boardName,
-      data,
-      clientIp,
-      userName,
-      "banned",
-    );
     return;
   }
 

--- a/server/socket/index.mjs
+++ b/server/socket/index.mjs
@@ -20,6 +20,7 @@ import {
 import { resetBans } from "./bans.mjs";
 import {
   boardStateForSocket,
+  clientIpFallback,
   getClientIp,
   normalizeBroadcastData,
 } from "./policy.mjs";
@@ -56,7 +57,7 @@ import {
   handleReportUserMessage,
   resetSocketReports,
 } from "./reports.mjs";
-import { getSocketRequest, getSocketUserSecret } from "./request.mjs";
+import { getSocketUserSecret } from "./request.mjs";
 import { handleTurnstileTokenMessage } from "./turnstile.mjs";
 
 const { Server } = socketIO;
@@ -345,12 +346,7 @@ function resolveClientIp(socket, boardName, config) {
         }),
       );
     }
-    // Fallback to remoteAddress
-    const request = getSocketRequest(socket);
-    if (request.socket?.remoteAddress) {
-      return request.socket.remoteAddress;
-    }
-    return "unknown";
+    return clientIpFallback(socket);
   }
 }
 
@@ -473,6 +469,9 @@ async function bootstrapSocketBoard(socket, replay, config) {
           }),
         );
       }
+      // Capabilities the joining socket has on this board. Reused both as the
+      // socket's own BOARDSTATE and as the capabilities other users see for it.
+      const boardState = boardStateForSocket(config, board, socket);
       const wasJoined = board.users.has(socket.id);
       board.users.add(socket.id);
       if (!wasJoined || !getBoardUserMap(boardName).has(socket.id)) {
@@ -481,6 +480,10 @@ async function bootstrapSocketBoard(socket, replay, config) {
           boardName,
           config,
           resolveClientIp,
+          {
+            canEdit: boardState.canEdit === true,
+            canClear: boardState.canClear === true,
+          },
         );
         if (!wasJoined) {
           connectedUsersTotal += 1;
@@ -503,10 +506,7 @@ async function bootstrapSocketBoard(socket, replay, config) {
           "wbo.socket.replay.count": replayCount,
         });
       }
-      socket.emit(
-        SocketEvents.BOARDSTATE,
-        boardStateForSocket(config, board, socket),
-      );
+      socket.emit(SocketEvents.BOARDSTATE, boardState);
       syncedPersistentSockets.delete(socket.id);
       socket.emit(SocketEvents.BROADCAST, replay.replayBatch);
       syncedPersistentSockets.add(socket.id);
@@ -859,6 +859,7 @@ export const __test = {
       boardName,
       config,
       resolveClientIp,
+      { canEdit: true, canClear: false },
       now,
     );
   },

--- a/server/socket/policy.mjs
+++ b/server/socket/policy.mjs
@@ -6,6 +6,7 @@ import {
 import RateLimitCommon from "../../client-data/js/rate_limit_common.js";
 import { BoardPermissions } from "../auth/board_capabilities.mjs";
 import observability from "../observability/index.mjs";
+import { isEditBanned } from "./bans.mjs";
 import { normalizeIncomingMessage } from "./message_validation.mjs";
 import { getSocketUserSecret } from "./request.mjs";
 
@@ -233,6 +234,30 @@ function getClientIp(config, socket) {
 }
 
 /**
+ * Last-resort client IP when the configured source is missing for a request.
+ * Shared so bans and presence key on the same value.
+ * @param {AppSocket} socket
+ * @returns {string}
+ */
+function clientIpFallback(socket) {
+  return socket.client?.request?.socket?.remoteAddress || "unknown";
+}
+
+/**
+ * Resolve the client IP without throwing (falls back via {@link clientIpFallback}).
+ * @param {SocketPolicyConfig} config
+ * @param {AppSocket} socket
+ * @returns {string}
+ */
+function resolveClientIpSafe(config, socket) {
+  try {
+    return getClientIp(config, socket);
+  } catch {
+    return clientIpFallback(socket);
+  }
+}
+
+/**
  * @param {MessageData | null | undefined} data
  * @returns {number}
  */
@@ -334,13 +359,22 @@ function boardPermissionsForSocket(config, boardName, socket) {
   const current = socket.boardPermissionContext;
   if (current?.boardName === boardName) return current.permissions;
 
+  const userSecret = getSocketUserSecret(socket);
   const permissions = BoardPermissions.forBoard({
     config,
     boardName,
-    userInfo: {
-      token: getSocketToken(socket),
-      userSecret: getSocketUserSecret(socket),
-    },
+    userInfo: { token: getSocketToken(socket), userSecret },
+    // Lazy + live: only resolved when a capability query depends on the ban
+    // (so canOpen never needs the IP), and re-read on every query so a ban and
+    // its expiry take effect without reconnecting. Tolerant of a missing IP
+    // source, keying on the same address presence records.
+    isBanned: () =>
+      isEditBanned(
+        boardName,
+        userSecret,
+        resolveClientIpSafe(config, socket),
+        Date.now(),
+      ),
   });
   socket.boardPermissionContext = { boardName, permissions };
   return permissions;
@@ -409,6 +443,7 @@ export {
   canApplyBoardMessage,
   canBanOnBoard,
   canEditBoard,
+  clientIpFallback,
   countConstructiveActions,
   countDestructiveActions,
   countTextCreationActions,

--- a/server/socket/policy.mjs
+++ b/server/socket/policy.mjs
@@ -234,27 +234,45 @@ function getClientIp(config, socket) {
 }
 
 /**
- * Last-resort client IP when the configured source is missing for a request.
- * Shared so bans and presence key on the same value.
+ * Last-resort client IP from a raw request when the configured source is missing.
+ * Shared so sockets, HTTP renders, bans, and presence all key on one value.
+ * @param {{socket?: {remoteAddress?: string}} | null | undefined} request
+ * @returns {string}
+ */
+function requestClientIpFallback(request) {
+  return request?.socket?.remoteAddress || "unknown";
+}
+
+/**
+ * Resolve a request's client IP without throwing.
+ * @param {SocketPolicyConfig} config
+ * @param {SocketRequest | {headers?: {[key: string]: string | string[] | undefined}, socket?: {remoteAddress?: string | undefined} | undefined}} request
+ * @returns {string}
+ */
+function resolveRequestClientIpSafe(config, request) {
+  try {
+    return getRequestClientIp(config, request);
+  } catch {
+    return requestClientIpFallback(request);
+  }
+}
+
+/**
  * @param {AppSocket} socket
  * @returns {string}
  */
 function clientIpFallback(socket) {
-  return socket.client?.request?.socket?.remoteAddress || "unknown";
+  return requestClientIpFallback(socket.client?.request);
 }
 
 /**
- * Resolve the client IP without throwing (falls back via {@link clientIpFallback}).
+ * Resolve a socket's client IP without throwing.
  * @param {SocketPolicyConfig} config
  * @param {AppSocket} socket
  * @returns {string}
  */
 function resolveClientIpSafe(config, socket) {
-  try {
-    return getClientIp(config, socket);
-  } catch {
-    return clientIpFallback(socket);
-  }
+  return resolveRequestClientIpSafe(config, socket.client?.request);
 }
 
 /**
@@ -444,6 +462,7 @@ export {
   canBanOnBoard,
   canEditBoard,
   clientIpFallback,
+  resolveRequestClientIpSafe,
   countConstructiveActions,
   countDestructiveActions,
   countTextCreationActions,

--- a/server/socket/presence.mjs
+++ b/server/socket/presence.mjs
@@ -14,8 +14,9 @@ import {
 } from "./request.mjs";
 
 /** @import { AppSocket, ConnectedUserPayload, NormalizedMessageData, ServerConfig } from "../../types/server-runtime.d.ts" */
-/** @typedef {{socketId: string, userId: string, userSecret: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number}} BoardUser */
+/** @typedef {{socketId: string, userId: string, userSecret: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, canEdit: boolean, canClear: boolean}} BoardUser */
 /** @typedef {(socket: AppSocket, boardName: string, config: ServerConfig) => string} ResolveClientIp */
+/** @typedef {{canEdit: boolean, canClear: boolean}} UserCapabilities */
 
 /** @type {Map<string, Map<string, BoardUser>>} */
 const boardUsers = new Map();
@@ -44,10 +45,18 @@ function buildUserName(ip, userSecret) {
  * @param {string} boardName
  * @param {ServerConfig} config
  * @param {ResolveClientIp} resolveClientIp
+ * @param {UserCapabilities} capabilities
  * @param {number} [now]
  * @returns {BoardUser}
  */
-function buildBoardUserRecord(socket, boardName, config, resolveClientIp, now) {
+function buildBoardUserRecord(
+  socket,
+  boardName,
+  config,
+  resolveClientIp,
+  capabilities,
+  now,
+) {
   const userSecret = getSocketUserSecret(socket);
   const ip = resolveClientIp(socket, boardName, config);
   const size = WBOMessageCommon.clampSize(
@@ -68,6 +77,8 @@ function buildBoardUserRecord(socket, boardName, config, resolveClientIp, now) {
     size,
     lastTool: getSocketQueryValue(socket, "tool") || "hand",
     lastSeen: now || Date.now(),
+    canEdit: capabilities.canEdit,
+    canClear: capabilities.canClear,
   };
 }
 
@@ -115,6 +126,8 @@ function serializeBoardUser(user) {
     color: user.color,
     size: user.size,
     lastTool: user.lastTool,
+    canEdit: user.canEdit,
+    canClear: user.canClear,
   };
 }
 
@@ -123,14 +136,27 @@ function serializeBoardUser(user) {
  * @param {string} boardName
  * @param {ServerConfig} config
  * @param {ResolveClientIp} resolveClientIp
+ * @param {UserCapabilities} capabilities
  * @returns {BoardUser}
  */
-function ensureBoardUser(socket, boardName, config, resolveClientIp) {
+function ensureBoardUser(
+  socket,
+  boardName,
+  config,
+  resolveClientIp,
+  capabilities,
+) {
   const users = getBoardUserMap(boardName);
   const existing = users.get(socket.id);
   if (existing) return existing;
 
-  const user = buildBoardUserRecord(socket, boardName, config, resolveClientIp);
+  const user = buildBoardUserRecord(
+    socket,
+    boardName,
+    config,
+    resolveClientIp,
+    capabilities,
+  );
   users.set(socket.id, user);
   return user;
 }

--- a/test-node/board_capabilities.test.js
+++ b/test-node/board_capabilities.test.js
@@ -114,3 +114,60 @@ test("board capabilities allow clear-capable JWT claims to clear boards", () => 
     canWrite: true,
   });
 });
+
+test("a live edit ban degrades a non-moderator to read-only", () => {
+  const { BoardPermissions } = require(BOARD_CAPABILITIES_PATH);
+  const config = createConfig({ AUTH_SECRET_KEY: "" });
+  const board = createBoard("open-board", false);
+  const permissions = BoardPermissions.forBoard({
+    config,
+    boardName: board.name,
+    userInfo: {},
+    isBanned: () => true,
+  });
+
+  assert.equal(permissions.canOpen(), true); // still allowed to view
+  assert.deepEqual(permissions.resolveCapabilities(board), {
+    canOpen: true,
+    canEdit: false,
+    canClear: false,
+  });
+});
+
+test("a moderator bypasses edit bans", () => {
+  const { BoardPermissions } = require(BOARD_CAPABILITIES_PATH);
+  const config = createConfig({ AUTH_SECRET_KEY: "test-secret" });
+  const token = tokenFor(config, { roles: ["moderator:clear-board"] });
+  const board = createBoard("clear-board", false);
+  const permissions = BoardPermissions.forBoard({
+    config,
+    boardName: board.name,
+    userInfo: { token },
+    isBanned: () => true,
+  });
+
+  assert.deepEqual(permissions.resolveCapabilities(board), {
+    canOpen: true,
+    canEdit: true,
+    canClear: true,
+  });
+});
+
+test("ban state is re-read live on each capability query", () => {
+  const { BoardPermissions } = require(BOARD_CAPABILITIES_PATH);
+  const config = createConfig({ AUTH_SECRET_KEY: "" });
+  const board = createBoard("open-board", false);
+  let banned = false;
+  const permissions = BoardPermissions.forBoard({
+    config,
+    boardName: board.name,
+    userInfo: {},
+    isBanned: () => banned,
+  });
+
+  assert.equal(permissions.resolveCapabilities(board).canEdit, true);
+  banned = true;
+  assert.equal(permissions.resolveCapabilities(board).canEdit, false);
+  banned = false; // e.g. the ban TTL expired
+  assert.equal(permissions.resolveCapabilities(board).canEdit, true);
+});

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -163,6 +163,20 @@ function parseRenderedBoardState(body) {
   return JSON.parse(json);
 }
 
+/**
+ * @param {import("http").IncomingHttpHeaders} headers
+ * @param {string[]} expected
+ * @returns {void}
+ */
+function assertVaryTokens(headers, expected) {
+  const tokens = String(headers.vary || "")
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .sort();
+  assert.deepEqual(tokens, expected.slice().sort());
+}
+
 test("in-process server imports do not register process signal handlers", async () => {
   const dirs = await createServerDirs();
   const sigintBefore = process.listenerCount("SIGINT");
@@ -947,6 +961,10 @@ test("board pages use seq-based etag and return 304 on cache hit", async () => {
 
     assert.equal(cachedResponse.statusCode, 304);
     assert.equal(cachedResponse.headers.etag, firstResponse.headers.etag);
+    assertVaryTokens(cachedResponse.headers, [
+      "Accept-Encoding",
+      "Accept-Language",
+    ]);
 
     const staleResponse = await request(app, "/boards/etag-board", {
       "If-None-Match": 'W/"wbo-seq-2"',
@@ -955,6 +973,90 @@ test("board pages use seq-based etag and return 304 on cache hit", async () => {
     assert.equal(staleResponse.statusCode, 200);
     assert.equal(staleResponse.headers.etag, 'W/"wbo-seq-3"');
   } finally {
+    await closeServer(app);
+  }
+});
+
+test("board page Vary headers include Cookie for non-default board shells", async () => {
+  const dirs = await createServerDirs();
+  const moderatorSecret = "dddddddddddddddddddddddddddddddd";
+  const bannedSecret = "cccccccccccccccccccccccccccccccc";
+  const bans = require(
+    path.join(__dirname, "..", "server", "socket", "bans.mjs"),
+  );
+  await fs.writeFile(
+    boardSvgFile(dirs.historyDir, "readonly-vary"),
+    '<svg id="canvas" xmlns="http://www.w3.org/2000/svg" version="1.1" width="5000" height="5000" data-wbo-format="whitebophir-svg-v2" data-wbo-seq="2" data-wbo-readonly="true"><defs id="defs"></defs><g id="drawingArea"></g><g id="cursors"></g></svg>',
+    "utf8",
+  );
+
+  const app = await createTestServer(
+    createServerConfig(dirs, {
+      WEBROOT: CLIENT_WEBROOT,
+      BOARD_MODERATORS: new Map([
+        ["moderator-vary", new Set([moderatorSecret])],
+      ]),
+    }),
+  );
+  try {
+    bans.resetBans();
+    bans.banBoardUser("banned-vary", bannedSecret, null, Date.now());
+
+    const defaultResponse = await request(app, "/boards/default-vary");
+    const moderatorResponse = await request(app, "/boards/moderator-vary", {
+      cookie: `wbo-user-secret-v1=${moderatorSecret}`,
+    });
+    const readonlyResponse = await request(app, "/boards/readonly-vary");
+    const bannedResponse = await request(app, "/boards/banned-vary", {
+      cookie: `wbo-user-secret-v1=${bannedSecret}`,
+    });
+    const localizedModeratorResponse = await request(
+      app,
+      "/boards/moderator-vary?lang=fr",
+      {
+        cookie: `wbo-user-secret-v1=${moderatorSecret}`,
+      },
+    );
+    const cachedReadonlyResponse = await request(app, "/boards/readonly-vary", {
+      "If-None-Match": String(readonlyResponse.headers.etag),
+    });
+
+    assert.equal(defaultResponse.statusCode, 200);
+    assert.equal(moderatorResponse.statusCode, 200);
+    assert.equal(readonlyResponse.statusCode, 200);
+    assert.equal(bannedResponse.statusCode, 200);
+    assert.equal(localizedModeratorResponse.statusCode, 200);
+    assert.equal(cachedReadonlyResponse.statusCode, 304);
+    assertVaryTokens(defaultResponse.headers, [
+      "Accept-Encoding",
+      "Accept-Language",
+    ]);
+    assertVaryTokens(moderatorResponse.headers, [
+      "Accept-Encoding",
+      "Accept-Language",
+      "Cookie",
+    ]);
+    assertVaryTokens(readonlyResponse.headers, [
+      "Accept-Encoding",
+      "Accept-Language",
+      "Cookie",
+    ]);
+    assertVaryTokens(bannedResponse.headers, [
+      "Accept-Encoding",
+      "Accept-Language",
+      "Cookie",
+    ]);
+    assertVaryTokens(localizedModeratorResponse.headers, [
+      "Accept-Encoding",
+      "Cookie",
+    ]);
+    assertVaryTokens(cachedReadonlyResponse.headers, [
+      "Accept-Encoding",
+      "Accept-Language",
+      "Cookie",
+    ]);
+  } finally {
+    bans.resetBans();
     await closeServer(app);
   }
 });

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -1342,3 +1342,46 @@ test("board-scoped JWTs can access their authorized board pages", async () => {
     await closeServer(app);
   }
 });
+
+test("banned users get a read-only board page while other visitors do not", async () => {
+  const dirs = await createServerDirs();
+  const bans = require(
+    path.join(__dirname, "..", "server", "socket", "bans.mjs"),
+  );
+  const bannedSecret = "cccccccccccccccccccccccccccccccc";
+  const app = await createTestServer(
+    createServerConfig(dirs, { WEBROOT: CLIENT_WEBROOT }),
+  );
+  try {
+    bans.banBoardUser("ban-http-render", bannedSecret, null, Date.now());
+
+    const bannedResponse = await request(app, "/boards/ban-http-render", {
+      cookie: `wbo-user-secret-v1=${bannedSecret}`,
+    });
+    const visitorResponse = await request(app, "/boards/ban-http-render");
+
+    // The banned user can still view the board, but the served HTML is
+    // read-only: no edit capability and no drawing tools in the toolbar.
+    assert.equal(bannedResponse.statusCode, 200);
+    assert.deepEqual(parseRenderedBoardState(bannedResponse.body), {
+      readonly: false,
+      canEdit: false,
+      canClear: false,
+      canWrite: false,
+    });
+    assert.match(bannedResponse.body, /toolID-hand/);
+    assert.doesNotMatch(bannedResponse.body, /toolID-pencil/);
+
+    // A different visitor on the same board is unaffected by the ban.
+    assert.deepEqual(parseRenderedBoardState(visitorResponse.body), {
+      readonly: false,
+      canEdit: true,
+      canClear: false,
+      canWrite: true,
+    });
+    assert.match(visitorResponse.body, /toolID-pencil/);
+  } finally {
+    bans.resetBans();
+    await closeServer(app);
+  }
+});

--- a/test-node/socket_users.test.js
+++ b/test-node/socket_users.test.js
@@ -423,6 +423,166 @@ test("socket boardstate uses the same capability-shaped state as rendered board 
   );
 });
 
+test("presence payloads expose canEdit/canClear for sidebar status", async () => {
+  const moderatorSecret = "dddddddddddddddddddddddddddddddd";
+  await createSocketScenario(
+    {
+      historyDirPrefix: "wbo-users-presence-caps-",
+      config: {
+        BOARD_MODERATORS: new Map([["caps-board", new Set([moderatorSecret])]]),
+      },
+    },
+    async ({ connect }) => {
+      await connect({
+        id: "socket-caps-mod",
+        remoteAddress: "203.0.113.90",
+        headers: withUserSecretCookie(moderatorSecret),
+        query: { board: "caps-board", tool: "hand" },
+      });
+      const viewer = await connect({
+        id: "socket-caps-viewer",
+        remoteAddress: "203.0.113.91",
+        headers: withUserSecretCookie("99999999999999999999999999999999"),
+        query: { board: "caps-board", tool: "hand" },
+      });
+
+      const joined = viewer.emitted.filter(
+        (event) => event.event === "user_joined",
+      );
+      const moderatorPayload = getRequiredValue(
+        joined.find((event) => event.payload.socketId === "socket-caps-mod"),
+      ).payload;
+      const viewerPayload = getRequiredValue(
+        joined.find((event) => event.payload.socketId === "socket-caps-viewer"),
+      ).payload;
+
+      assert.equal(moderatorPayload.canEdit, true);
+      assert.equal(moderatorPayload.canClear, true);
+      assert.equal(viewerPayload.canEdit, true);
+      assert.equal(viewerPayload.canClear, false);
+    },
+  );
+});
+
+test("presence reflects JWT moderator role, not just configured moderators", async () => {
+  const authSecret = "test-secret";
+  const moderatorToken = jsonwebtoken.sign(
+    { sub: "mod", roles: ["moderator:jwt-caps-board"] },
+    authSecret,
+  );
+  const editorToken = jsonwebtoken.sign(
+    { sub: "ed", roles: ["editor:jwt-caps-board"] },
+    authSecret,
+  );
+
+  await createSocketScenario(
+    {
+      historyDirPrefix: "wbo-users-presence-jwt-mod-",
+      config: { AUTH_SECRET_KEY: authSecret },
+    },
+    async ({ connect }) => {
+      await connect({
+        id: "socket-jwt-mod",
+        remoteAddress: "203.0.113.92",
+        headers: withUserSecretCookie("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"),
+        token: moderatorToken,
+        query: { board: "jwt-caps-board", tool: "hand" },
+      });
+      const viewer = await connect({
+        id: "socket-jwt-viewer",
+        remoteAddress: "203.0.113.93",
+        headers: withUserSecretCookie("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac"),
+        token: editorToken,
+        query: { board: "jwt-caps-board", tool: "hand" },
+      });
+
+      const moderatorPayload = getRequiredValue(
+        viewer.emitted
+          .filter((event) => event.event === "user_joined")
+          .find((event) => event.payload.socketId === "socket-jwt-mod"),
+      ).payload;
+      assert.equal(moderatorPayload.canClear, true);
+      assert.equal(moderatorPayload.canEdit, true);
+    },
+  );
+});
+
+test("a banned user reconnects read-only in their own boardstate and in presence", async () => {
+  const moderatorSecret = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+  const targetSecret = "ffffffffffffffffffffffffffffffff";
+  await createSocketScenario(
+    {
+      historyDirPrefix: "wbo-users-banned-readonly-",
+      config: {
+        BOARD_MODERATORS: new Map([
+          ["ban-readonly-board", new Set([moderatorSecret])],
+        ]),
+      },
+    },
+    async ({ connect, handler }) => {
+      const moderator = await connect({
+        id: "socket-ban-mod",
+        remoteAddress: "203.0.113.94",
+        headers: withUserSecretCookie(moderatorSecret),
+        query: { board: "ban-readonly-board", tool: "hand" },
+      });
+      await connect({
+        id: "socket-ban-target",
+        remoteAddress: "203.0.113.95",
+        headers: withUserSecretCookie(targetSecret),
+        query: { board: "ban-readonly-board", tool: "hand" },
+      });
+
+      handler(moderator, "report_user")({ socketId: "socket-ban-target" });
+
+      // The banned user reconnects (same secret + ip): now read-only everywhere.
+      const reconnected = await connect({
+        id: "socket-ban-target-2",
+        remoteAddress: "203.0.113.95",
+        headers: withUserSecretCookie(targetSecret),
+        query: { board: "ban-readonly-board", tool: "hand" },
+      });
+
+      // Own boardstate hides editing tools.
+      assert.equal(
+        getRequiredValue(
+          reconnected.emitted.find((event) => event.event === "boardstate"),
+        ).payload.canEdit,
+        false,
+      );
+      // Own presence row.
+      assert.equal(
+        getRequiredValue(
+          reconnected.emitted
+            .filter((event) => event.event === "user_joined")
+            .find((event) => event.payload.socketId === "socket-ban-target-2"),
+        ).payload.canEdit,
+        false,
+      );
+      // What other users on the board receive.
+      assert.equal(
+        getRequiredValue(
+          reconnected.broadcasted.find(
+            (event) =>
+              event.event === "user_joined" &&
+              event.payload.socketId === "socket-ban-target-2",
+          ),
+        ).payload.canEdit,
+        false,
+      );
+
+      // The moderator stays fully capable.
+      const moderatorPayload = getRequiredValue(
+        moderator.emitted
+          .filter((event) => event.event === "user_joined")
+          .find((event) => event.payload.socketId === "socket-ban-mod"),
+      ).payload;
+      assert.equal(moderatorPayload.canEdit, true);
+      assert.equal(moderatorPayload.canClear, true);
+    },
+  );
+});
+
 test("connection replay records outcome metrics with signed seq gap inputs", async () => {
   await createSocketScenario(
     { historyDirPrefix: "wbo-users-connection-replay-metrics-" },
@@ -1985,7 +2145,7 @@ test("moderator report bans reported secret and ip without disconnecting moderat
         getRequiredValue(
           sameIp.emitted.find((event) => event.event === "mutation_rejected"),
         ).payload,
-        { clientMutationId: "cm-ip-ban", reason: "banned" },
+        { clientMutationId: "cm-ip-ban", reason: "write_blocked" },
       );
 
       const sameSecret = await connect({
@@ -2014,7 +2174,7 @@ test("moderator report bans reported secret and ip without disconnecting moderat
             (event) => event.event === "mutation_rejected",
           ),
         ).payload,
-        { clientMutationId: "cm-secret-ban", reason: "banned" },
+        { clientMutationId: "cm-secret-ban", reason: "write_blocked" },
       );
 
       await invoke(

--- a/types/app-runtime.d.ts
+++ b/types/app-runtime.d.ts
@@ -340,6 +340,8 @@ export type ConnectedUser = {
   color: string;
   size: number;
   lastTool: string;
+  canEdit?: boolean;
+  canClear?: boolean;
   lastFocusX?: number;
   lastFocusY?: number;
   lastActivityAt?: number;


### PR DESCRIPTION
The connected-users sidebar now flags moderators with a 🌸 and italicises read-only users.

Instead of a one-off `banned` flag, each user's presence carries `canEdit`/`canClear`, the same capability vocabulary already sent per-client via `BOARDSTATE`. An edit ban folds into the capability resolver as a live predicate, so a banned non-moderator is read-only in their own UI, on the write path, and in the presence other users see, all from one source of truth. That let me delete the duplicate ban check in `broadcasts.mjs`.

Capabilities are resolved once at join from the socket's authoritative permissions, so JWT moderators are flagged too, not just configured ones.

Verified with `npm run test-node` (331 pass, including new presence / ban-readonly / JWT-moderator cases) and `npm run typecheck`.