### PR TITLE
Quality: Duplicate type declaration for jsonwebtoken module

### DIFF
--- a/playwright/types/jsonwebtoken.d.ts
+++ b/playwright/types/jsonwebtoken.d.ts
@@ -1,1 +1,0 @@
-declare module "jsonwebtoken";


### PR DESCRIPTION
## Summary

Quality: Duplicate type declaration for jsonwebtoken module

## Problem

**Severity**: `Low` | **File**: `playwright/types/jsonwebtoken.d.ts:L1`

The `declare module "jsonwebtoken"` is declared in both `types/external-modules.d.ts` and `playwright/types/jsonwebtoken.d.ts`. This redundancy can lead to maintenance issues and potential type conflicts.

## Solution

Remove the duplicate declaration from `playwright/types/jsonwebtoken.d.ts` and reference the one in `types/external-modules.d.ts` instead, or consolidate all module declarations in a single location.

## Changes

- `playwright/types/jsonwebtoken.d.ts` (modified)