### PR TITLE
Add confirmation warning to Clear tool

### DIFF
--- a/client-data/js/board_tool_registry_module.js
+++ b/client-data/js/board_tool_registry_module.js
@@ -715,6 +715,7 @@ export function createToolRuntimeModules(mountedTools, ownerToolName = "") {
       },
     },
     config: mountedTools.config,
+    i18n: mountedTools.i18n,
     ids: mountedTools.ids,
     messages: {
       /** @param {RuntimeBoardMessage} message */

--- a/client-data/tools/clear/index.js
+++ b/client-data/tools/clear/index.js
@@ -50,9 +50,18 @@ function createClearMessage(state) {
   };
 }
 
+const CLEAR_CONFIRMATION_MESSAGE =
+  "⚠️ WARNING: This will permanently clear the entire board for everyone.\n\nAre you sure you want to continue?";
+
+function confirmClearBoard() {
+  return window.confirm(CLEAR_CONFIRMATION_MESSAGE);
+}
+
 /** @param {ClearToolState} state */
 export function onstart(state) {
+  if (!confirmClearBoard()) return false;
   state.writes.drawAndSend(createClearMessage(state));
+  return true;
 }
 
 /** @param {ClearToolState} state */

--- a/client-data/tools/clear/index.js
+++ b/client-data/tools/clear/index.js
@@ -50,16 +50,14 @@ function createClearMessage(state) {
   };
 }
 
-const CLEAR_CONFIRMATION_MESSAGE =
-  "⚠️ WARNING: This will permanently clear the entire board for everyone.\n\nAre you sure you want to continue?";
-
-function confirmClearBoard() {
-  return window.confirm(CLEAR_CONFIRMATION_MESSAGE);
+/** @param {ClearToolState} state */
+function confirmClearBoard(state) {
+  return window.confirm(state.i18n.t("clear_confirmation_message"));
 }
 
 /** @param {ClearToolState} state */
 export function onstart(state) {
-  if (!confirmClearBoard()) return false;
+  if (!confirmClearBoard(state)) return false;
   state.writes.drawAndSend(createClearMessage(state));
   return true;
 }
@@ -74,6 +72,7 @@ export function boot(ctx) {
   return {
     board: ctx.runtime.board,
     identity: ctx.runtime.identity,
+    i18n: ctx.runtime.i18n,
     writes: ctx.runtime.writes,
   };
 }

--- a/playwright/tests/auth.spec.ts
+++ b/playwright/tests/auth.spec.ts
@@ -89,6 +89,18 @@ test.describe("JWT auth and readonly flows", () => {
     });
     await expect(boardPage.tool("clear")).toBeVisible();
     await expect(page.locator(clearSelector)).toBeVisible();
+
+    page.once("dialog", async (dialog) => {
+      expect(dialog.message()).toContain("WARNING");
+      await dialog.dismiss();
+    });
+    await boardPage.tool("clear").click();
+    await expect(page.locator(clearSelector)).toBeVisible();
+
+    page.once("dialog", async (dialog) => {
+      expect(dialog.message()).toContain("permanently clear the entire board");
+      await dialog.accept();
+    });
     await boardPage.tool("clear").click();
     await server.waitForStoredBoard(
       server.dataPath,

--- a/playwright/tests/drawing.spec.ts
+++ b/playwright/tests/drawing.spec.ts
@@ -434,6 +434,9 @@ test.describe("drawing and persistence", () => {
       await expect(visibleStroke).toHaveCount(1);
       await expect(boardPage.statusIndicator).toBeVisible();
 
+      peerPage.once("dialog", async (dialog) => {
+        await dialog.accept();
+      });
       await peerBoard.tool("clear").click();
       await page.mouse.up();
 

--- a/server/http/translations.json
+++ b/server/http/translations.json
@@ -49,7 +49,8 @@
     "selector": "محدد",
     "open_board": "فتح",
     "white_out": "مسح الكل",
-    "turnstile_status_prefix": "يقول فحص مكافحة الروبوتات:"
+    "turnstile_status_prefix": "يقول فحص مكافحة الروبوتات:",
+    "clear_confirmation_message": "⚠️ تحذير: سيؤدي هذا إلى مسح اللوحة بأكملها نهائيًا للجميع.\n\nهل أنت متأكد أنك تريد المتابعة؟"
   },
   "be": {
     "white-out": "Замазка",
@@ -101,7 +102,8 @@
     "selector": "Выбар",
     "open_board": "Адкрыць",
     "white_out": "Замазка",
-    "turnstile_status_prefix": "Антыробат-фільтр паведамляе:"
+    "turnstile_status_prefix": "Антыробат-фільтр паведамляе:",
+    "clear_confirmation_message": "⚠️ УВАГА: гэта назаўсёды ачысціць усю дошку для ўсіх.\n\nВы ўпэўненыя, што хочаце працягнуць?"
   },
   "ca": {
     "white-out": "Corrector blanc",
@@ -153,7 +155,8 @@
     "selector": "Selector",
     "open_board": "Obre",
     "white_out": "Corrector blanc",
-    "turnstile_status_prefix": "El filtre antirobot indica:"
+    "turnstile_status_prefix": "El filtre antirobot indica:",
+    "clear_confirmation_message": "⚠️ AVÍS: això esborrarà permanentment tota la pissarra per a tothom.\n\nSegur que voleu continuar?"
   },
   "de": {
     "board_name_placeholder": "Name des Whiteboards…",
@@ -205,7 +208,8 @@
     "selector": "Auswahl",
     "open_board": "Öffnen",
     "white_out": "Korrekturflüssigkeit",
-    "turnstile_status_prefix": "Der Anti-Roboter-Filter meldet:"
+    "turnstile_status_prefix": "Der Anti-Roboter-Filter meldet:",
+    "clear_confirmation_message": "⚠️ WARNUNG: Dadurch wird das gesamte Board für alle dauerhaft gelöscht.\n\nMöchten Sie wirklich fortfahren?"
   },
   "en": {
     "white-out": "White-out",
@@ -257,7 +261,8 @@
     "selector": "Selector",
     "open_board": "Go",
     "white_out": "White-out",
-    "turnstile_status_prefix": "The anti-robot check says:"
+    "turnstile_status_prefix": "The anti-robot check says:",
+    "clear_confirmation_message": "⚠️ WARNING: This will permanently clear the entire board for everyone.\n\nAre you sure you want to continue?"
   },
   "es": {
     "board_name_placeholder": "Nombre de la pizarra …",
@@ -309,7 +314,8 @@
     "download": "Descargar",
     "open_board": "Ir",
     "white_out": "Blanqueado",
-    "turnstile_status_prefix": "El filtro anti-robot indica:"
+    "turnstile_status_prefix": "El filtro anti-robot indica:",
+    "clear_confirmation_message": "⚠️ ADVERTENCIA: Esto borrará permanentemente toda la pizarra para todos.\n\n¿Seguro que quieres continuar?"
   },
   "fr": {
     "board_name_placeholder": "Nom du tableau…",
@@ -360,7 +366,8 @@
     "zoom": "Zoom",
     "open_board": "Ouvrir",
     "white_out": "Blanco",
-    "turnstile_status_prefix": "Le filtre anti-robot indique :"
+    "turnstile_status_prefix": "Le filtre anti-robot indique :",
+    "clear_confirmation_message": "⚠️ AVERTISSEMENT : cela effacera définitivement tout le tableau pour tout le monde.\n\nVoulez-vous vraiment continuer ?"
   },
   "hu": {
     "white-out": "Lefedő",
@@ -412,7 +419,8 @@
     "selector": "Kijelölő",
     "open_board": "Megnyitás",
     "white_out": "Lefedő",
-    "turnstile_status_prefix": "A robotellenes szűrő jelzi:"
+    "turnstile_status_prefix": "A robotellenes szűrő jelzi:",
+    "clear_confirmation_message": "⚠️ FIGYELMEZTETÉS: Ez véglegesen törli az egész táblát mindenki számára.\n\nBiztosan folytatni szeretné?"
   },
   "id": {
     "white-out": "Cairan koreksi",
@@ -464,7 +472,8 @@
     "selector": "Pemilih",
     "open_board": "Buka",
     "white_out": "Cairan koreksi",
-    "turnstile_status_prefix": "Filter anti-robot menyatakan:"
+    "turnstile_status_prefix": "Filter anti-robot menyatakan:",
+    "clear_confirmation_message": "⚠️ PERINGATAN: Tindakan ini akan menghapus seluruh papan secara permanen untuk semua orang.\n\nApakah Anda yakin ingin melanjutkan?"
   },
   "it": {
     "board_name_placeholder": "Nome della lavagna…",
@@ -516,7 +525,8 @@
     "download": "Scarica",
     "open_board": "Apri",
     "white_out": "Bianchetto",
-    "turnstile_status_prefix": "Il filtro anti-robot indica:"
+    "turnstile_status_prefix": "Il filtro anti-robot indica:",
+    "clear_confirmation_message": "⚠️ ATTENZIONE: questa azione cancellerà definitivamente tutta la lavagna per tutti.\n\nVuoi davvero continuare?"
   },
   "ja": {
     "board_name_placeholder": "ボードの名前",
@@ -568,7 +578,8 @@
     "selector": "選択",
     "open_board": "開く",
     "white_out": "修正液",
-    "turnstile_status_prefix": "ロボット対策チェックの結果:"
+    "turnstile_status_prefix": "ロボット対策チェックの結果:",
+    "clear_confirmation_message": "⚠️ 警告: これにより、全員のボード全体が完全に消去されます。\n\n続行してもよろしいですか？"
   },
   "my": {
     "board_name_placeholder": "ဝှိုက်ဘုတ်အမည် ... ",
@@ -620,7 +631,8 @@
     "selector": "ရွေးချယ်ကိရိယာ",
     "open_board": "ဖွင့်ရန်",
     "white_out": "ပြုပြင်မှုအရည်",
-    "turnstile_status_prefix": "ရိုဘော့တ်တားဆီးရေးစစ်ဆေးမှုက ဖော်ပြသည်:"
+    "turnstile_status_prefix": "ရိုဘော့တ်တားဆီးရေးစစ်ဆေးမှုက ဖော်ပြသည်:",
+    "clear_confirmation_message": "⚠️ သတိပေးချက်: ဤလုပ်ဆောင်ချက်သည် လူတိုင်းအတွက် ဘုတ်တစ်ခုလုံးကို အပြီးတိုင် ဖျက်ပစ်ပါမည်။\n\nဆက်လုပ်ရန် သေချာပါသလား။"
   },
   "pt": {
     "white-out": "Branquejar",
@@ -672,7 +684,8 @@
     "download": "Baixar",
     "open_board": "Abrir",
     "white_out": "Branquejar",
-    "turnstile_status_prefix": "O filtro anti-robô indica:"
+    "turnstile_status_prefix": "O filtro anti-robô indica:",
+    "clear_confirmation_message": "⚠️ AVISO: Isto apagará permanentemente todo o quadro para todos.\n\nTem certeza de que deseja continuar?"
   },
   "ru": {
     "board_name_placeholder": "Название доски",
@@ -724,7 +737,8 @@
     "click_to_zoom": "Нажмите, чтобы увеличить\nНажмите Shift и щёлкните, чтобы уменьшить",
     "open_board": "Открыть",
     "white_out": "Корректор",
-    "turnstile_status_prefix": "Антиробот-фильтр сообщает:"
+    "turnstile_status_prefix": "Антиробот-фильтр сообщает:",
+    "clear_confirmation_message": "⚠️ ВНИМАНИЕ: это навсегда очистит всю доску для всех.\n\nВы уверены, что хотите продолжить?"
   },
   "sw": {
     "board_name_placeholder": "Jina la ubao mweupe ...",
@@ -776,7 +790,8 @@
     "selector": "Kiteuzi",
     "open_board": "Fungua",
     "white_out": "maji ya kusahihisha",
-    "turnstile_status_prefix": "Kichujio cha kuzuia roboti kinasema:"
+    "turnstile_status_prefix": "Kichujio cha kuzuia roboti kinasema:",
+    "clear_confirmation_message": "⚠️ ONYO: Hii itafuta kabisa ubao mzima kwa kila mtu.\n\nUna uhakika unataka kuendelea?"
   },
   "th": {
     "board_name_placeholder": "ชื่อไวท์บอร์ด ...",
@@ -828,7 +843,8 @@
     "selector": "ตัวเลือก",
     "open_board": "เปิด",
     "white_out": "น้ำยาลบคำผิด",
-    "turnstile_status_prefix": "ตัวกรองป้องกันหุ่นยนต์ระบุว่า:"
+    "turnstile_status_prefix": "ตัวกรองป้องกันหุ่นยนต์ระบุว่า:",
+    "clear_confirmation_message": "⚠️ คำเตือน: การดำเนินการนี้จะล้างทั้งกระดานอย่างถาวรสำหรับทุกคน\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?"
   },
   "uk": {
     "white-out": "Коректор",
@@ -880,7 +896,8 @@
     "selector": "Вибір",
     "open_board": "Відкрити",
     "white_out": "Коректор",
-    "turnstile_status_prefix": "Антиробот-фільтр повідомляє:"
+    "turnstile_status_prefix": "Антиробот-фільтр повідомляє:",
+    "clear_confirmation_message": "⚠️ УВАГА: це назавжди очистить усю дошку для всіх.\n\nВи впевнені, що хочете продовжити?"
   },
   "vi": {
     "white-out": "Bút xóa",
@@ -932,7 +949,8 @@
     "selector": "Bộ chọn",
     "open_board": "Mở",
     "white_out": "Bút xóa",
-    "turnstile_status_prefix": "Bộ lọc chống robot cho biết:"
+    "turnstile_status_prefix": "Bộ lọc chống robot cho biết:",
+    "clear_confirmation_message": "⚠️ CẢNH BÁO: Thao tác này sẽ xóa vĩnh viễn toàn bộ bảng cho mọi người.\n\nBạn có chắc chắn muốn tiếp tục không?"
   },
   "zh-CN": {
     "board_name_placeholder": "白板名称",
@@ -984,7 +1002,8 @@
     "selector": "选择器",
     "open_board": "打开",
     "white_out": "修正液",
-    "turnstile_status_prefix": "反机器人检查提示："
+    "turnstile_status_prefix": "反机器人检查提示：",
+    "clear_confirmation_message": "⚠️ 警告：这将为所有人永久清空整个白板。\n\n确定要继续吗？"
   },
   "zh-TW": {
     "board_name_placeholder": "白板名稱",
@@ -1036,7 +1055,8 @@
     "download": "下載",
     "open_board": "開啟",
     "white_out": "修正液",
-    "turnstile_status_prefix": "防機器人檢查提示："
+    "turnstile_status_prefix": "防機器人檢查提示：",
+    "clear_confirmation_message": "⚠️ 警告：這會為所有人永久清空整個白板。\n\n確定要繼續嗎？"
   },
   "pl": {
     "board_name_placeholder": "Nazwa tablicy",
@@ -1088,6 +1108,7 @@
     "click_to_zoom": "Kliknij, aby powiększyć\nNaciśnij Shift i kliknij, aby pomniejszyć",
     "open_board": "Otwórz",
     "white_out": "Korektor",
-    "turnstile_status_prefix": "Filtr antyrobotowy informuje:"
+    "turnstile_status_prefix": "Filtr antyrobotowy informuje:",
+    "clear_confirmation_message": "⚠️ OSTRZEŻENIE: To trwale wyczyści całą tablicę dla wszystkich.\n\nCzy na pewno chcesz kontynuować?"
   }
 }

--- a/test-node/client_tool_replay.test.js
+++ b/test-node/client_tool_replay.test.js
@@ -939,6 +939,9 @@ function createInputToolRuntime(tools) {
     toolRegistry: tools.toolRegistry,
     interaction: tools.interaction,
     config: tools.config,
+    i18n: tools.i18n || {
+      t: (s) => s,
+    },
     ids: tools.ids,
     messages: {
       messageForTool: () => unavailableCapability("messages.messageForTool"),
@@ -966,6 +969,7 @@ function createHarnessToolRuntime(app) {
     toolRegistry: app.toolRegistry,
     interaction: app.interaction,
     config: app.config,
+    i18n: app.i18n,
     ids: app.ids,
     messages: app.messages,
     permissions: app.access,


### PR DESCRIPTION
### Motivation
- Prevent accidental destructive clears by requiring an explicit confirmation with a strong warning before sending the clear-board mutation.

### Description
- Added a `CLEAR_CONFIRMATION_MESSAGE` and a `confirmClearBoard()` prompt that shows a prominent warning and requires user confirmation before clearing the board in `client-data/tools/clear/index.js`.
- `onstart` now aborts if the user dismisses the confirmation and only calls `state.writes.drawAndSend(createClearMessage(state))` when accepted.
- Updated Playwright coverage to assert the dialog behavior by dismissing the first dialog and then accepting it to proceed in `playwright/tests/auth.spec.ts`.
- Adjusted the remote-clear interaction in `playwright/tests/drawing.spec.ts` to accept the new confirmation dialog before clicking clear.

### Testing
- Ran `npm run lint` and it completed without errors.
- Ran `npm run typecheck` and it completed without errors.
- Attempted `npx playwright test playwright/tests/auth.spec.ts playwright/tests/drawing.spec.ts`, but Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so browser tests did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3387173b688331b0510a4094d5404d)