### PR TITLE
Protect moderators from complaints

### DIFF
--- a/client-data/js/board_presence_module.js
+++ b/client-data/js/board_presence_module.js
@@ -552,8 +552,10 @@ function updateConnectedUserRow(getTools, row, user) {
     row.querySelector(".connected-user-report")
   );
   if (report) {
-    report.hidden = !!(user.reported && !isCurrentSocketUser(Tools, user));
-    report.disabled = isCurrentSocketUser(Tools, user);
+    const currentSocketUser = isCurrentSocketUser(Tools, user);
+    report.hidden =
+      user.canClear === true || !!(user.reported && !currentSocketUser);
+    report.disabled = currentSocketUser;
     report.classList.toggle("connected-user-report-latched", !!user.reported);
   }
 }
@@ -597,7 +599,13 @@ function createConnectedUserRow(getTools, user, users) {
     const Tools = getTools();
     if (!Tools.connection.socket || !row.dataset.socketId) return;
     const connectedUser = users.get(row.dataset.socketId);
-    if (!connectedUser || isCurrentSocketUser(Tools, connectedUser)) return;
+    if (
+      !connectedUser ||
+      connectedUser.canClear === true ||
+      isCurrentSocketUser(Tools, connectedUser)
+    ) {
+      return;
+    }
     connectedUser.reported = true;
     updateConnectedUserRow(getTools, row, connectedUser);
     Tools.connection.socket.emit(SocketEvents.REPORT_USER, {

--- a/server/socket/policy.mjs
+++ b/server/socket/policy.mjs
@@ -411,6 +411,7 @@ function canAccessBoard(config, boardName, socket) {
 }
 
 /**
+ * Returns true when the given socket belongs to an user who has the permission to ban others on the board.
  * @param {SocketPolicyConfig} config
  * @param {string} boardName
  * @param {AppSocket} socket

--- a/server/socket/reports.mjs
+++ b/server/socket/reports.mjs
@@ -72,23 +72,15 @@ function buildUserReportLog(boardName, { reported, reporter }, banned) {
 
 /**
  * @param {string} boardName
- * @param {AppSocket[]} socketsToDisconnect
+ * @param {AppSocket} targetSocket
  * @param {CloseSocket} closeSocket
  * @returns {void}
  */
-function disconnectReportedSockets(
-  boardName,
-  socketsToDisconnect,
-  closeSocket,
-) {
-  socketsToDisconnect.forEach(
-    function disconnectReportedUser(/** @type {AppSocket} */ targetSocket) {
-      closeSocket(targetSocket, "report_user", {
-        board: boardName,
-        socket: targetSocket.id,
-      });
-    },
-  );
+function disconnectReportSocket(boardName, targetSocket, closeSocket) {
+  closeSocket(targetSocket, "report_user", {
+    board: boardName,
+    socket: targetSocket.id,
+  });
 }
 
 /**
@@ -110,58 +102,68 @@ function isSelfReportTarget(reporter, reported) {
  * @param {{reporter: BoardUser, reported: BoardUser}} users
  * @returns {void}
  */
-function handleModeratorReport(context, users) {
-  if (isSelfReportTarget(users.reporter, users.reported)) {
+function handleReportByModerator(context, { reporter, reported }) {
+  const board = context.boardName;
+  if (isSelfReportTarget(reporter, reported)) {
     tracing.setActiveSpanAttributes({
       "wbo.board.result": "self_report_ignored",
     });
     logger.warn("user.ban_skipped_self_report", {
-      board: context.boardName,
-      reporter_socket: users.reporter.socketId,
-      reported_socket: users.reported.socketId,
-      reporter_name: users.reporter.name,
-      reported_name: users.reported.name,
+      board,
+      reporter_socket: reporter.socketId,
+      reported_socket: reported.socketId,
+      reporter_name: reporter.name,
+      reported_name: reported.name,
     });
     return;
   }
 
   banBoardUser(
     context.boardName,
-    users.reported.userSecret,
-    users.reported.ip,
+    reported.userSecret,
+    reported.ip,
     context.now,
   );
   logger.warn("user.banned", {
-    board: context.boardName,
-    reported_ip: users.reported.ip,
-    reported_name: users.reported.name,
-    by: users.reporter.name,
+    board,
+    reported_ip: reported.ip,
+    reported_name: reported.name,
+    by: reporter.name,
   });
-  const reportedSocket = context.getActiveSocket(users.reported.socketId);
-  disconnectReportedSockets(
+  const reportedSocket = context.getActiveSocket(reported.socketId);
+  if (!reportedSocket) {
+    logger.error("user.ban.fail", { reported, reporter, board });
+    return;
+  }
+  disconnectReportSocket(board, reportedSocket, context.closeSocket);
+}
+
+/**
+ * @param {ReportUserContext} context
+ * @returns {void}
+ */
+function disconnectReporter(context) {
+  disconnectReportSocket(
     context.boardName,
-    reportedSocket ? [reportedSocket] : [],
+    context.socket,
     context.closeSocket,
   );
 }
 
 /**
  * @param {ReportUserContext} context
- * @param {{reporter: BoardUser, reported: BoardUser}} users
+ * @param {BoardUser} reported
  * @returns {void}
  */
-function handleLegacyReportDisconnect(context, users) {
-  const reportedSocket = context.getActiveSocket(users.reported.socketId);
-  disconnectReportedSockets(
-    context.boardName,
-    [
-      context.socket,
-      ...(reportedSocket && reportedSocket !== context.socket
-        ? [reportedSocket]
-        : []),
-    ],
-    context.closeSocket,
-  );
+function disconnectReported(context, reported) {
+  const reportedSocket = context.getActiveSocket(reported.socketId);
+  if (reportedSocket && reportedSocket !== context.socket) {
+    disconnectReportSocket(
+      context.boardName,
+      reportedSocket,
+      context.closeSocket,
+    );
+  }
 }
 
 /**
@@ -169,15 +171,16 @@ function handleLegacyReportDisconnect(context, users) {
  * @returns {void}
  */
 function handleReportUserMessage(context) {
-  const targetSocketId = getReportedSocketId(context.message);
-  if (!targetSocketId || !context.socket.rooms.has(context.boardName)) {
+  const { message, boardName, socket, config } = context;
+  const targetSocketId = getReportedSocketId(message);
+  if (!targetSocketId || !socket.rooms.has(boardName)) {
     ignoreReportedUser();
     return;
   }
 
   const resolvedUsers = resolveReportedUsers(
-    context.boardName,
-    context.socket.id,
+    boardName,
+    socket.id,
     targetSocketId,
   );
   if (!resolvedUsers) {
@@ -185,44 +188,48 @@ function handleReportUserMessage(context) {
     return;
   }
 
-  if (resolvedUsers.reported.canClear === true) {
-    ignoreReportedUser("protected_report_ignored");
-    logger.warn("user.report_skipped_protected_target", {
-      board: context.boardName,
-      reporter_socket: resolvedUsers.reporter.socketId,
-      reported_socket: resolvedUsers.reported.socketId,
-      reporter_name: resolvedUsers.reporter.name,
-      reported_name: resolvedUsers.reported.name,
-    });
+  const banned = canBanOnBoard(config, boardName, socket);
+
+  if (banned) {
+    handleReportByModerator(context, resolvedUsers);
     return;
   }
 
-  const banned = canBanOnBoard(
-    context.config,
-    context.boardName,
-    context.socket,
-  );
+  if (resolvedUsers.reported.canClear === true) {
+    handleReportedModerator(context, boardName, resolvedUsers);
+    return;
+  }
 
-  const reportLog = buildUserReportLog(
-    context.boardName,
-    resolvedUsers,
-    banned,
-  );
-  lastUserReportLog = reportLog;
   tracing.setActiveSpanAttributes({
     "wbo.board.result": "reported",
     "user.name": resolvedUsers.reporter.name,
     "wbo.reported_user.name": resolvedUsers.reported.name,
   });
-
-  if (banned) {
-    handleModeratorReport(context, resolvedUsers);
-    return;
-  }
-
+  const reportLog = buildUserReportLog(boardName, resolvedUsers, banned);
+  lastUserReportLog = reportLog;
   logger.warn("user.reported", reportLog);
 
-  handleLegacyReportDisconnect(context, resolvedUsers);
+  // Disconnect the reporter too to prevent abuse.
+  disconnectReporter(context);
+  disconnectReported(context, resolvedUsers.reported);
+}
+
+/**
+ *
+ * @param {ReportUserContext} context
+ * @param {string} board
+ * @param {ReportUsers} resolvedUsers
+ */
+function handleReportedModerator(context, board, resolvedUsers) {
+  disconnectReporter(context);
+  ignoreReportedUser("protected_report_ignored");
+  logger.warn("user.report_skipped_protected_target", {
+    board,
+    reporter_socket: resolvedUsers.reporter.socketId,
+    reported_socket: resolvedUsers.reported.socketId,
+    reporter_name: resolvedUsers.reporter.name,
+    reported_name: resolvedUsers.reported.name,
+  });
 }
 
 /**

--- a/server/socket/reports.mjs
+++ b/server/socket/reports.mjs
@@ -6,7 +6,7 @@ import { canBanOnBoard } from "./policy.mjs";
 const { logger, tracing } = observability;
 
 /** @import { AppSocket, ReportUserPayload, ServerConfig } from "../../types/server-runtime.d.ts" */
-/** @typedef {{socketId: string, name: string, ip: string, userSecret?: string, userAgent: string, language: string}} BoardUser */
+/** @typedef {{socketId: string, name: string, ip: string, userSecret?: string, userAgent: string, language: string, canClear?: boolean}} BoardUser */
 /** @typedef {{board: string, reporter_socket: string, reported_socket: string, reporter_ip: string, reported_ip: string, reporter_user_agent: string, reported_user_agent: string, reporter_language: string, reported_language: string, reporter_name: string, reported_name: string, banned: boolean}} UserReportLog */
 /** @typedef {(socketId: string) => AppSocket | undefined} GetActiveSocket */
 /** @typedef {(socket: AppSocket, eventName: string, infos: {[key: string]: any}) => void} CloseSocket */
@@ -40,9 +40,9 @@ function resolveReportedUsers(boardName, reporterSocketId, reportedSocketId) {
 /**
  * @returns {void}
  */
-function ignoreReportedUser() {
+function ignoreReportedUser(result = "ignored") {
   tracing.setActiveSpanAttributes({
-    "wbo.board.result": "ignored",
+    "wbo.board.result": result,
   });
 }
 
@@ -182,6 +182,18 @@ function handleReportUserMessage(context) {
   );
   if (!resolvedUsers) {
     ignoreReportedUser();
+    return;
+  }
+
+  if (resolvedUsers.reported.canClear === true) {
+    ignoreReportedUser("protected_report_ignored");
+    logger.warn("user.report_skipped_protected_target", {
+      board: context.boardName,
+      reporter_socket: resolvedUsers.reporter.socketId,
+      reported_socket: resolvedUsers.reported.socketId,
+      reporter_name: resolvedUsers.reporter.name,
+      reported_name: resolvedUsers.reported.name,
+    });
     return;
   }
 

--- a/test-node/socket_users.test.js
+++ b/test-node/socket_users.test.js
@@ -465,7 +465,7 @@ test("presence payloads expose canEdit/canClear for sidebar status", async () =>
   );
 });
 
-test("report_user ignores canClear targets without disconnecting either user", async () => {
+test("report_user ignores canClear targets without disconnecting the moderator", async () => {
   const moderatorSecret = "fdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfd";
   await createSocketScenario(
     {
@@ -497,7 +497,7 @@ test("report_user ignores canClear targets without disconnecting either user", a
         socketId: "socket-report-protected-mod",
       });
 
-      assert.equal(reporter.socket.client.conn.closeCalls.length, 0);
+      assert.equal(reporter.socket.client.conn.closeCalls.length, 1);
       assert.equal(moderator.socket.client.conn.closeCalls.length, 0);
       assert.equal(test.getLastUserReportLog(), null);
     },

--- a/test-node/socket_users.test.js
+++ b/test-node/socket_users.test.js
@@ -465,6 +465,45 @@ test("presence payloads expose canEdit/canClear for sidebar status", async () =>
   );
 });
 
+test("report_user ignores canClear targets without disconnecting either user", async () => {
+  const moderatorSecret = "fdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfd";
+  await createSocketScenario(
+    {
+      historyDirPrefix: "wbo-users-report-protected-",
+      config: {
+        BOARD_MODERATORS: new Map([
+          ["report-protected-board", new Set([moderatorSecret])],
+        ]),
+      },
+    },
+    async ({ connect, handler, test }) => {
+      const reporter = await connect({
+        id: "socket-report-protected-reporter",
+        remoteAddress: "203.0.113.92",
+        headers: withUserSecretCookie("88888888888888888888888888888888"),
+        query: { board: "report-protected-board", tool: "hand" },
+      });
+      const moderator = await connect({
+        id: "socket-report-protected-mod",
+        remoteAddress: "203.0.113.93",
+        headers: withUserSecretCookie(moderatorSecret),
+        query: { board: "report-protected-board", tool: "hand" },
+      });
+
+      handler(
+        reporter,
+        "report_user",
+      )({
+        socketId: "socket-report-protected-mod",
+      });
+
+      assert.equal(reporter.socket.client.conn.closeCalls.length, 0);
+      assert.equal(moderator.socket.client.conn.closeCalls.length, 0);
+      assert.equal(test.getLastUserReportLog(), null);
+    },
+  );
+});
+
 test("presence reflects JWT moderator role, not just configured moderators", async () => {
   const authSecret = "test-secret";
   const moderatorToken = jsonwebtoken.sign(


### PR DESCRIPTION
### Motivation
- Moderators (users with the `canClear` capability) should not be able to be reported via the UI and should not be disconnected or banned when someone attempts to report them.

### Description
- Hide and disable the connected-user report button for users with `canClear` and add a click-time guard so the client never emits `SocketEvents.REPORT_USER` for protected users (`client-data/js/board_presence_module.js`).
- Treat report targets that have `canClear` as protected on the server by skipping disconnect/ban handling, setting a distinct tracing result (`protected_report_ignored`), and logging a warning instead of disconnecting (`server/socket/reports.mjs`).
- Extend the `BoardUser` typedef to include `canClear` so server-side logic can inspect protection status (`server/socket/reports.mjs`).
- Add a Node test that verifies reporting a `canClear` target does not disconnect either socket and does not create a report log (`test-node/socket_users.test.js`).

### Testing
- Ran `npm run lint` and the lint pass completed successfully.
- Ran `npm run typecheck` and the typecheck completed successfully.
- Ran the socket users Node tests including the new test `report_user ignores canClear targets without disconnecting either user`, and it passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3387a66acc8331b095b102f4b506b5)