### PR TITLE
Add VS Code devcontainer with Playwright and Chromium

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm
+FROM mcr.microsoft.com/devcontainers/javascript-node:24-trixie
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        less \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/playwright-bootstrap
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts \
+    && npx playwright install --with-deps chromium \
+    && rm -rf /tmp/playwright-bootstrap /root/.npm \
+    && chmod -R 755 /ms-playwright
+
+USER node
+WORKDIR /workspace/whitebophir

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "WBO development",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "node",
+  "containerEnv": {
+    "PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright",
+    "WBO_SILENT": "true"
+  },
+  "forwardPorts": [5001],
+  "portsAttributes": {
+    "5001": {
+      "label": "WBO dev server",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "npm ci",
+  "customizations": {
+    "vscode": {
+      "extensions": ["biomejs.biome", "ms-playwright.playwright"]
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a reproducible development container that includes everything required to run the app and the Playwright e2e browser tests so contributors don't need to install system browser libraries locally.

### Description
- Add `.devcontainer/Dockerfile` based on `mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm` that sets `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, installs small CLI packages, runs `npm ci --ignore-scripts` and `npx playwright install --with-deps chromium`, and leaves the image ready for the non-root `node` user in `/workspace/whitebophir`.
- Add `.devcontainer/devcontainer.json` that builds from the repo context, uses `remoteUser: "node"`, exports `PLAYWRIGHT_BROWSERS_PATH` and `WBO_SILENT`, forwards port `5001`, runs `postCreateCommand: "npm ci"`, and recommends the `biomejs.biome` and `ms-playwright.playwright` VS Code extensions.
- Keep the container configuration minimal and formatted with the repo `biome` settings for readability and consistency.

### Testing
- Validated the devcontainer JSON with `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json','utf8'))"` which succeeded.
- Ran `npm run lint` and `npm run typecheck`, both of which completed successfully.
- Ran `npm test`: the Node unit tests passed, but the Playwright browser tests failed when run on the current host because Chromium system libraries are missing (`libatk-1.0.so.0`), which is expected to be resolved when running inside the devcontainer where `npx playwright install --with-deps chromium` installs required dependencies; a full container build could not be executed here because the Docker CLI is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a338a93361c83319679269d3ee134bf)