### PR TITLE
Track connected user focus positions

### DIFF
--- a/client-data/js/board_presence_module.js
+++ b/client-data/js/board_presence_module.js
@@ -297,7 +297,7 @@ function getConnectedUserToolLabel(Tools, user) {
  * @returns {boolean}
  */
 function hasConnectedUserFocus(user) {
-  return Number.isFinite(user.lastFocusX) && Number.isFinite(user.lastFocusY);
+  return Number.isFinite(user.position?.x) && Number.isFinite(user.position?.y);
 }
 
 /**
@@ -477,8 +477,8 @@ function markConnectedUserActivity(user, scheduleActivityRender) {
 function getConnectedUserFocusHash(Tools, user) {
   if (!hasConnectedUserFocus(user)) return "";
   const scale = Tools.viewportState.controller.getScale();
-  const x = /** @type {number} */ (user.lastFocusX);
-  const y = /** @type {number} */ (user.lastFocusY);
+  const x = user.position.x;
+  const y = user.position.y;
   return `#${Math.max(0, (x - window.innerWidth / (2 * scale)) | 0)},${Math.max(
     0,
     (y - window.innerHeight / (2 * scale)) | 0,
@@ -666,9 +666,8 @@ function applyConnectedUserActivity(
   ) {
     const nextFocusX = /** @type {{x: number, y: number}} */ (focusPoint).x;
     const nextFocusY = /** @type {{x: number, y: number}} */ (focusPoint).y;
-    if (user.lastFocusX !== nextFocusX || user.lastFocusY !== nextFocusY) {
-      user.lastFocusX = nextFocusX;
-      user.lastFocusY = nextFocusY;
+    if (user.position.x !== nextFocusX || user.position.y !== nextFocusY) {
+      user.position = { x: nextFocusX, y: nextFocusY };
       changed = true;
     }
   }

--- a/client-data/js/message_shape.js
+++ b/client-data/js/message_shape.js
@@ -51,8 +51,19 @@ export function hasMessageNewId(message) {
  * @returns {message is MessageWithPoint}
  */
 export function hasMessagePoint(message) {
+  return extractMessagePosition(message) !== null;
+}
+
+/**
+ * @param {unknown} message
+ * @returns {{x: number, y: number} | null}
+ */
+export function extractMessagePosition(message) {
   const point = messageRecord(message);
-  return typeof point?.x === "number" && typeof point.y === "number";
+  const x = point?.x;
+  const y = point?.y;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { x: /** @type {number} */ (x), y: /** @type {number} */ (y) };
 }
 
 /**
@@ -60,7 +71,16 @@ export function hasMessagePoint(message) {
  * @returns {message is MessageWithColor}
  */
 export function hasMessageColor(message) {
-  return typeof messageRecord(message)?.color === "string";
+  return extractMessageColor(message) !== null;
+}
+
+/**
+ * @param {unknown} message
+ * @returns {string | null}
+ */
+export function extractMessageColor(message) {
+  const color = messageRecord(message)?.color;
+  return typeof color === "string" ? color : null;
 }
 
 /**
@@ -68,5 +88,14 @@ export function hasMessageColor(message) {
  * @returns {message is MessageWithSize}
  */
 export function hasMessageSize(message) {
-  return typeof messageRecord(message)?.size === "number";
+  return extractMessageSize(message) !== null;
+}
+
+/**
+ * @param {unknown} message
+ * @returns {number | null}
+ */
+export function extractMessageSize(message) {
+  const size = messageRecord(message)?.size;
+  return Number.isFinite(size) ? /** @type {number} */ (size) : null;
 }

--- a/playwright/tests/collaboration.spec.ts
+++ b/playwright/tests/collaboration.spec.ts
@@ -115,7 +115,9 @@ test.describe("collaboration and rate limiting", () => {
 
     await peerBoard.forceScrollTopLeft();
     await peerPage
-      .locator("#connectedUsersList .connected-user-main-link[href^='#']")
+      .locator(
+        "#connectedUsersList .connected-user-row:not(.connected-user-row-self) .connected-user-main-link[href^='#']",
+      )
       .click();
     await expect
       .poll(() => peerBoard.scrollPosition())

--- a/server/socket/broadcasts.mjs
+++ b/server/socket/broadcasts.mjs
@@ -25,7 +25,7 @@ const { logger, metrics, tracing } = observability;
 
 /** @import { AppSocket, MessageData, MutationLogEntry, NormalizedMessageData, SequencedMutationBroadcastData, ServerConfig } from "../../types/server-runtime.d.ts" */
 /** @import { BoardData } from "../board/data.mjs" */
-/** @typedef {{socketId: string, userId: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, lastFocusX: number, lastFocusY: number}} BoardUser */
+/** @typedef {{socketId: string, userId: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, position: {x: number, y: number}}} BoardUser */
 /**
  * @typedef {{
  *   getActiveSocket: (socketId: string) => AppSocket | undefined,

--- a/server/socket/broadcasts.mjs
+++ b/server/socket/broadcasts.mjs
@@ -25,7 +25,7 @@ const { logger, metrics, tracing } = observability;
 
 /** @import { AppSocket, MessageData, MutationLogEntry, NormalizedMessageData, SequencedMutationBroadcastData, ServerConfig } from "../../types/server-runtime.d.ts" */
 /** @import { BoardData } from "../board/data.mjs" */
-/** @typedef {{socketId: string, userId: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number}} BoardUser */
+/** @typedef {{socketId: string, userId: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, lastFocusX: number, lastFocusY: number}} BoardUser */
 /**
  * @typedef {{
  *   getActiveSocket: (socketId: string) => AppSocket | undefined,

--- a/server/socket/presence.mjs
+++ b/server/socket/presence.mjs
@@ -14,7 +14,7 @@ import {
 } from "./request.mjs";
 
 /** @import { AppSocket, ConnectedUserPayload, NormalizedMessageData, ServerConfig } from "../../types/server-runtime.d.ts" */
-/** @typedef {{socketId: string, userId: string, userSecret: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, canEdit: boolean, canClear: boolean}} BoardUser */
+/** @typedef {{socketId: string, userId: string, userSecret: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, lastFocusX: number, lastFocusY: number, canEdit: boolean, canClear: boolean}} BoardUser */
 /** @typedef {(socket: AppSocket, boardName: string, config: ServerConfig) => string} ResolveClientIp */
 /** @typedef {{canEdit: boolean, canClear: boolean}} UserCapabilities */
 
@@ -77,6 +77,8 @@ function buildBoardUserRecord(
     size,
     lastTool: getSocketQueryValue(socket, "tool") || "hand",
     lastSeen: now || Date.now(),
+    lastFocusX: 0,
+    lastFocusY: 0,
     canEdit: capabilities.canEdit,
     canClear: capabilities.canClear,
   };
@@ -126,6 +128,8 @@ function serializeBoardUser(user) {
     color: user.color,
     size: user.size,
     lastTool: user.lastTool,
+    lastFocusX: user.lastFocusX,
+    lastFocusY: user.lastFocusY,
     canEdit: user.canEdit,
     canClear: user.canClear,
   };
@@ -238,6 +242,15 @@ function updateBoardUserFromMessage(socket, boardName, data, now) {
   if (hasMessageSize(data)) user.size = data.size || user.size;
   const toolId = getToolId(data.tool);
   if (data.tool !== Cursor.id && toolId) user.lastTool = toolId;
+  if (
+    "x" in data &&
+    "y" in data &&
+    Number.isFinite(data.x) &&
+    Number.isFinite(data.y)
+  ) {
+    user.lastFocusX = data.x;
+    user.lastFocusY = data.y;
+  }
   return user;
 }
 

--- a/server/socket/presence.mjs
+++ b/server/socket/presence.mjs
@@ -1,7 +1,8 @@
 import WBOMessageCommon from "../../client-data/js/message_common.js";
 import {
-  hasMessageColor,
-  hasMessageSize,
+  extractMessageColor,
+  extractMessagePosition,
+  extractMessageSize,
 } from "../../client-data/js/message_shape.js";
 import { getToolId } from "../../client-data/js/message_tool_metadata.js";
 import { SocketEvents } from "../../client-data/js/socket_events.js";
@@ -14,7 +15,7 @@ import {
 } from "./request.mjs";
 
 /** @import { AppSocket, ConnectedUserPayload, NormalizedMessageData, ServerConfig } from "../../types/server-runtime.d.ts" */
-/** @typedef {{socketId: string, userId: string, userSecret: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, lastFocusX: number, lastFocusY: number, canEdit: boolean, canClear: boolean}} BoardUser */
+/** @typedef {{socketId: string, userId: string, userSecret: string, name: string, ip: string, userAgent: string, language: string, color: string, size: number, lastTool: string, lastSeen: number, position: {x: number, y: number}, canEdit: boolean, canClear: boolean}} BoardUser */
 /** @typedef {(socket: AppSocket, boardName: string, config: ServerConfig) => string} ResolveClientIp */
 /** @typedef {{canEdit: boolean, canClear: boolean}} UserCapabilities */
 
@@ -77,8 +78,7 @@ function buildBoardUserRecord(
     size,
     lastTool: getSocketQueryValue(socket, "tool") || "hand",
     lastSeen: now || Date.now(),
-    lastFocusX: 0,
-    lastFocusY: 0,
+    position: { x: 0, y: 0 },
     canEdit: capabilities.canEdit,
     canClear: capabilities.canClear,
   };
@@ -128,8 +128,7 @@ function serializeBoardUser(user) {
     color: user.color,
     size: user.size,
     lastTool: user.lastTool,
-    lastFocusX: user.lastFocusX,
-    lastFocusY: user.lastFocusY,
+    position: user.position,
     canEdit: user.canEdit,
     canClear: user.canClear,
   };
@@ -238,19 +237,14 @@ function updateBoardUserFromMessage(socket, boardName, data, now) {
   if (!user) return undefined;
 
   user.lastSeen = now;
-  if (hasMessageColor(data)) user.color = data.color;
-  if (hasMessageSize(data)) user.size = data.size || user.size;
+  const color = extractMessageColor(data);
+  if (color) user.color = color;
+  const size = extractMessageSize(data);
+  if (size) user.size = size;
   const toolId = getToolId(data.tool);
   if (data.tool !== Cursor.id && toolId) user.lastTool = toolId;
-  if (
-    "x" in data &&
-    "y" in data &&
-    Number.isFinite(data.x) &&
-    Number.isFinite(data.y)
-  ) {
-    user.lastFocusX = data.x;
-    user.lastFocusY = data.y;
-  }
+  const position = extractMessagePosition(data);
+  if (position) user.position = position;
   return user;
 }
 

--- a/test-node/board_presence_module.test.js
+++ b/test-node/board_presence_module.test.js
@@ -122,6 +122,8 @@ function createConnectedUser() {
     color: "#123456",
     size: 4,
     lastTool: "hand",
+    lastFocusX: 0,
+    lastFocusY: 0,
   };
 }
 
@@ -166,7 +168,7 @@ test("presence activity treats rendered focus measurement as best-effort", async
     const user = presence.users.get("sock-1");
     assert.ok(user);
     assert.equal(user.lastTool, "hand");
-    assert.equal(user.lastFocusX, undefined);
+    assert.equal(user.lastFocusX, 0);
   } finally {
     env.restore();
   }
@@ -194,7 +196,7 @@ test("presence focus ignores elements outside the attached drawing area", async 
     });
     const user = presence.users.get("sock-1");
     assert.ok(user);
-    assert.equal(user.lastFocusX, undefined);
+    assert.equal(user.lastFocusX, 0);
   } finally {
     env.restore();
   }

--- a/test-node/board_presence_module.test.js
+++ b/test-node/board_presence_module.test.js
@@ -122,8 +122,7 @@ function createConnectedUser() {
     color: "#123456",
     size: 4,
     lastTool: "hand",
-    lastFocusX: 0,
-    lastFocusY: 0,
+    position: { x: 0, y: 0 },
   };
 }
 
@@ -168,7 +167,7 @@ test("presence activity treats rendered focus measurement as best-effort", async
     const user = presence.users.get("sock-1");
     assert.ok(user);
     assert.equal(user.lastTool, "hand");
-    assert.equal(user.lastFocusX, 0);
+    assert.deepEqual(user.position, { x: 0, y: 0 });
   } finally {
     env.restore();
   }
@@ -196,7 +195,7 @@ test("presence focus ignores elements outside the attached drawing area", async 
     });
     const user = presence.users.get("sock-1");
     assert.ok(user);
-    assert.equal(user.lastFocusX, 0);
+    assert.deepEqual(user.position, { x: 0, y: 0 });
   } finally {
     env.restore();
   }

--- a/test-node/socket_users.test.js
+++ b/test-node/socket_users.test.js
@@ -461,6 +461,10 @@ test("presence payloads expose canEdit/canClear for sidebar status", async () =>
       assert.equal(moderatorPayload.canClear, true);
       assert.equal(viewerPayload.canEdit, true);
       assert.equal(viewerPayload.canClear, false);
+      assert.equal(moderatorPayload.lastFocusX, 0);
+      assert.equal(moderatorPayload.lastFocusY, 0);
+      assert.equal(viewerPayload.lastFocusX, 0);
+      assert.equal(viewerPayload.lastFocusY, 0);
     },
   );
 });
@@ -1828,6 +1832,8 @@ test("live broadcasts attach socket attribution and keep the user's latest non-c
       assert.equal(user.lastTool, "rectangle");
       assert.equal(user.color, "#abcdef");
       assert.equal(user.size, 12);
+      assert.equal(user.lastFocusX, 9);
+      assert.equal(user.lastFocusY, 10);
       let cursorBroadcast;
       for (let index = created.broadcasted.length - 1; index >= 0; index--) {
         const event = created.broadcasted[index];

--- a/test-node/socket_users.test.js
+++ b/test-node/socket_users.test.js
@@ -461,10 +461,8 @@ test("presence payloads expose canEdit/canClear for sidebar status", async () =>
       assert.equal(moderatorPayload.canClear, true);
       assert.equal(viewerPayload.canEdit, true);
       assert.equal(viewerPayload.canClear, false);
-      assert.equal(moderatorPayload.lastFocusX, 0);
-      assert.equal(moderatorPayload.lastFocusY, 0);
-      assert.equal(viewerPayload.lastFocusX, 0);
-      assert.equal(viewerPayload.lastFocusY, 0);
+      assert.deepEqual(moderatorPayload.position, { x: 0, y: 0 });
+      assert.deepEqual(viewerPayload.position, { x: 0, y: 0 });
     },
   );
 });
@@ -1832,8 +1830,7 @@ test("live broadcasts attach socket attribution and keep the user's latest non-c
       assert.equal(user.lastTool, "rectangle");
       assert.equal(user.color, "#abcdef");
       assert.equal(user.size, 12);
-      assert.equal(user.lastFocusX, 9);
-      assert.equal(user.lastFocusY, 10);
+      assert.deepEqual(user.position, { x: 9, y: 10 });
       let cursorBroadcast;
       for (let index = created.broadcasted.length - 1; index >= 0; index--) {
         const event = created.broadcasted[index];

--- a/types/app-runtime.d.ts
+++ b/types/app-runtime.d.ts
@@ -342,8 +342,10 @@ export type ConnectedUser = {
   lastTool: string;
   canEdit?: boolean;
   canClear?: boolean;
-  lastFocusX: number;
-  lastFocusY: number;
+  position: {
+    x: number;
+    y: number;
+  };
   lastActivityAt?: number;
   pulseMs?: number;
   pulseUntil?: number;

--- a/types/app-runtime.d.ts
+++ b/types/app-runtime.d.ts
@@ -342,8 +342,8 @@ export type ConnectedUser = {
   lastTool: string;
   canEdit?: boolean;
   canClear?: boolean;
-  lastFocusX?: number;
-  lastFocusY?: number;
+  lastFocusX: number;
+  lastFocusY: number;
   lastActivityAt?: number;
   pulseMs?: number;
   pulseUntil?: number;


### PR DESCRIPTION
### Motivation
- The server should always track a last-known board position for each connected user so the frontend can immediately teleport to any user.  
- Presence payloads must include deterministic focus coordinates to remove the notion of an un-teleportable user in the UI.

### Description
- Add `lastFocusX` and `lastFocusY` to server-side `BoardUser` records and initialize them to `0` in `server/socket/presence.mjs` (`buildBoardUserRecord`).
- Include `lastFocusX`/`lastFocusY` in serialized presence payloads (`serializeBoardUser`) and in the `BoardUser` typedef propagated into `server/socket/broadcasts.mjs`.
- Update `updateBoardUserFromMessage` to set `lastFocusX`/`lastFocusY` when an accepted message carries finite `x` and `y` coordinates (covers cursor and other point messages).
- Make connected-user focus coordinates required in the runtime types (`types/app-runtime.d.ts`) and update focused presence tests to assert the new default and cursor-driven updates.

### Testing
- Ran the focused Node tests: `node --test test-node/board_presence_module.test.js test-node/socket_users.test.js` and they passed.  
- Ran the static typecheck: `npm run typecheck` and it completed without errors.  
- Ran staged formatting/checks via `git diff --check` as part of the commit and there were no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3391b055388331809aa5b8a444ad4c)