### PR TITLE
Notify moderators of user reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,15 @@ The server validates client messages, rejects malformed writes with
 `mutation_rejected`, and rebroadcasts accepted persistent writes as sequenced
 `broadcast` frames.
 
+User reports are sent by clients on the `report_user` event with a payload of
+`{ "socketId": "<reported socket id>" }`. Non-moderator reports disconnect the
+reporter and reported user after logging the report. For accepted non-moderator
+reports, the server emits `user_reported` only to connected moderators on that
+board. The `user_reported` payload is
+`{ "reporterName": "<display name>", "reportedName": "<display name>" }`.
+Moderator report-to-ban actions do not emit `user_reported`; they ban and
+disconnect the reported user directly.
+
 Client write messages normally have top-level `tool` and `type` fields.
 Tool-owned batches have top-level `tool` plus `_children`; each child carries its
 own mutation `type`. Normal socket batches are capped by `WBO_MAX_CHILDREN`, but

--- a/client-data/js/board_connection_module.js
+++ b/client-data/js/board_connection_module.js
@@ -243,6 +243,9 @@ export class ConnectionModule {
       socket.on(SocketEvents.USER_LEFT, function onUserLeft(user) {
         Tools.presence.removeConnectedUser(user.socketId);
       });
+      socket.on(SocketEvents.USER_REPORTED, function onUserReported(payload) {
+        Tools.status.showUserReportNotice(payload);
+      });
       socket.on(SocketEvents.RATE_LIMITED, function onRateLimited(payload) {
         const retryAfterMs = Math.max(0, Number(payload.retryAfterMs) || 0);
         Tools.writes.serverRateLimitedUntil = Date.now() + retryAfterMs;

--- a/client-data/js/board_status_module.js
+++ b/client-data/js/board_status_module.js
@@ -8,6 +8,18 @@ function getBoardStatusElements() {
   };
 }
 
+/**
+ * @param {string} template
+ * @param {{[key: string]: string}} values
+ * @returns {string}
+ */
+function formatStatusMessage(template, values) {
+  return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(values, key)) return match;
+    return values[key] || "";
+  });
+}
+
 export class StatusModule {
   /**
    * @param {() => AppToolsState} getTools
@@ -78,6 +90,31 @@ export class StatusModule {
       title: Tools.i18n.t("unknown_error_reload_page"),
       detail: "",
     });
+  }
+
+  /**
+   * @param {{reporterName?: string, reportedName?: string}} payload
+   */
+  showUserReportNotice(payload) {
+    const Tools = this.getTools();
+    const reporterName =
+      typeof payload?.reporterName === "string" ? payload.reporterName : "";
+    const reportedName =
+      typeof payload?.reportedName === "string" ? payload.reportedName : "";
+    if (!reporterName || !reportedName) return;
+
+    this.showBoardStatus(
+      {
+        hidden: false,
+        state: "paused",
+        title: formatStatusMessage(Tools.i18n.t("user_report_notice"), {
+          reporter: reporterName,
+          reported: reportedName,
+        }),
+        detail: "",
+      },
+      6000,
+    );
   }
 
   /**

--- a/client-data/js/socket_events.js
+++ b/client-data/js/socket_events.js
@@ -9,6 +9,7 @@ export const SocketEvents = Object.freeze({
   RATE_LIMITED: "rate-limited",
   REPORT_USER: "report_user",
   TURNSTILE_TOKEN: "turnstile_token",
+  USER_REPORTED: "user_reported",
   USER_JOINED: "user_joined",
   USER_LEFT: "user_left",
 });

--- a/server/http/translations.json
+++ b/server/http/translations.json
@@ -51,7 +51,8 @@
     "white_out": "مسح الكل",
     "turnstile_status_prefix": "يقول فحص مكافحة الروبوتات:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ تحذير: سيؤدي هذا إلى مسح اللوحة بأكملها نهائيًا للجميع.\n\nهل أنت متأكد أنك تريد المتابعة؟"
+    "clear_confirmation_message": "⚠️ تحذير: سيؤدي هذا إلى مسح اللوحة بأكملها نهائيًا للجميع.\n\nهل أنت متأكد أنك تريد المتابعة؟",
+    "user_report_notice": "{reporter} اشتكى من {reported}"
   },
   "be": {
     "white-out": "Замазка",
@@ -105,7 +106,8 @@
     "white_out": "Замазка",
     "turnstile_status_prefix": "Антыробат-фільтр паведамляе:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ УВАГА: гэта назаўсёды ачысціць усю дошку для ўсіх.\n\nВы ўпэўненыя, што хочаце працягнуць?"
+    "clear_confirmation_message": "⚠️ УВАГА: гэта назаўсёды ачысціць усю дошку для ўсіх.\n\nВы ўпэўненыя, што хочаце працягнуць?",
+    "user_report_notice": "{reporter} паскардзіўся на {reported}"
   },
   "ca": {
     "white-out": "Corrector blanc",
@@ -159,7 +161,8 @@
     "white_out": "Corrector blanc",
     "turnstile_status_prefix": "El filtre antirobot indica:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ AVÍS: això esborrarà permanentment tota la pissarra per a tothom.\n\nSegur que voleu continuar?"
+    "clear_confirmation_message": "⚠️ AVÍS: això esborrarà permanentment tota la pissarra per a tothom.\n\nSegur que voleu continuar?",
+    "user_report_notice": "{reporter} s'ha queixat de {reported}"
   },
   "de": {
     "board_name_placeholder": "Name des Whiteboards…",
@@ -213,7 +216,8 @@
     "white_out": "Korrekturflüssigkeit",
     "turnstile_status_prefix": "Der Anti-Roboter-Filter meldet:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ WARNUNG: Dadurch wird das gesamte Board für alle dauerhaft gelöscht.\n\nMöchten Sie wirklich fortfahren?"
+    "clear_confirmation_message": "⚠️ WARNUNG: Dadurch wird das gesamte Board für alle dauerhaft gelöscht.\n\nMöchten Sie wirklich fortfahren?",
+    "user_report_notice": "{reporter} hat sich über {reported} beschwert"
   },
   "en": {
     "white-out": "White-out",
@@ -267,7 +271,8 @@
     "white_out": "White-out",
     "turnstile_status_prefix": "The anti-robot check says:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ WARNING: This will permanently clear the entire board for everyone.\n\nAre you sure you want to continue?"
+    "clear_confirmation_message": "⚠️ WARNING: This will permanently clear the entire board for everyone.\n\nAre you sure you want to continue?",
+    "user_report_notice": "{reporter} complained about {reported}"
   },
   "es": {
     "board_name_placeholder": "Nombre de la pizarra …",
@@ -321,7 +326,8 @@
     "white_out": "Blanqueado",
     "turnstile_status_prefix": "El filtro anti-robot indica:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ ADVERTENCIA: Esto borrará permanentemente toda la pizarra para todos.\n\n¿Seguro que quieres continuar?"
+    "clear_confirmation_message": "⚠️ ADVERTENCIA: Esto borrará permanentemente toda la pizarra para todos.\n\n¿Seguro que quieres continuar?",
+    "user_report_notice": "{reporter} se quejó de {reported}"
   },
   "fr": {
     "board_name_placeholder": "Nom du tableau…",
@@ -374,7 +380,8 @@
     "white_out": "Blanco",
     "turnstile_status_prefix": "Le filtre anti-robot indique :",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ AVERTISSEMENT : cela effacera définitivement tout le tableau pour tout le monde.\n\nVoulez-vous vraiment continuer ?"
+    "clear_confirmation_message": "⚠️ AVERTISSEMENT : cela effacera définitivement tout le tableau pour tout le monde.\n\nVoulez-vous vraiment continuer ?",
+    "user_report_notice": "{reporter} a signalé {reported}"
   },
   "hu": {
     "white-out": "Lefedő",
@@ -428,7 +435,8 @@
     "white_out": "Lefedő",
     "turnstile_status_prefix": "A robotellenes szűrő jelzi:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ FIGYELMEZTETÉS: Ez véglegesen törli az egész táblát mindenki számára.\n\nBiztosan folytatni szeretné?"
+    "clear_confirmation_message": "⚠️ FIGYELMEZTETÉS: Ez véglegesen törli az egész táblát mindenki számára.\n\nBiztosan folytatni szeretné?",
+    "user_report_notice": "{reporter} panaszt tett {reported} ellen"
   },
   "id": {
     "white-out": "Cairan koreksi",
@@ -482,7 +490,8 @@
     "white_out": "Cairan koreksi",
     "turnstile_status_prefix": "Filter anti-robot menyatakan:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ PERINGATAN: Tindakan ini akan menghapus seluruh papan secara permanen untuk semua orang.\n\nApakah Anda yakin ingin melanjutkan?"
+    "clear_confirmation_message": "⚠️ PERINGATAN: Tindakan ini akan menghapus seluruh papan secara permanen untuk semua orang.\n\nApakah Anda yakin ingin melanjutkan?",
+    "user_report_notice": "{reporter} mengeluhkan {reported}"
   },
   "it": {
     "board_name_placeholder": "Nome della lavagna…",
@@ -536,7 +545,8 @@
     "white_out": "Bianchetto",
     "turnstile_status_prefix": "Il filtro anti-robot indica:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ ATTENZIONE: questa azione cancellerà definitivamente tutta la lavagna per tutti.\n\nVuoi davvero continuare?"
+    "clear_confirmation_message": "⚠️ ATTENZIONE: questa azione cancellerà definitivamente tutta la lavagna per tutti.\n\nVuoi davvero continuare?",
+    "user_report_notice": "{reporter} ha segnalato {reported}"
   },
   "ja": {
     "board_name_placeholder": "ボードの名前",
@@ -590,7 +600,8 @@
     "white_out": "修正液",
     "turnstile_status_prefix": "ロボット対策チェックの結果:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ 警告: これにより、全員のボード全体が完全に消去されます。\n\n続行してもよろしいですか？"
+    "clear_confirmation_message": "⚠️ 警告: これにより、全員のボード全体が完全に消去されます。\n\n続行してもよろしいですか？",
+    "user_report_notice": "{reporter} が {reported} について報告しました"
   },
   "my": {
     "board_name_placeholder": "ဝှိုက်ဘုတ်အမည် ... ",
@@ -644,7 +655,8 @@
     "white_out": "ပြုပြင်မှုအရည်",
     "turnstile_status_prefix": "ရိုဘော့တ်တားဆီးရေးစစ်ဆေးမှုက ဖော်ပြသည်:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ သတိပေးချက်: ဤလုပ်ဆောင်ချက်သည် လူတိုင်းအတွက် ဘုတ်တစ်ခုလုံးကို အပြီးတိုင် ဖျက်ပစ်ပါမည်။\n\nဆက်လုပ်ရန် သေချာပါသလား။"
+    "clear_confirmation_message": "⚠️ သတိပေးချက်: ဤလုပ်ဆောင်ချက်သည် လူတိုင်းအတွက် ဘုတ်တစ်ခုလုံးကို အပြီးတိုင် ဖျက်ပစ်ပါမည်။\n\nဆက်လုပ်ရန် သေချာပါသလား။",
+    "user_report_notice": "{reporter} က {reported} ကို တိုင်ကြားခဲ့သည်"
   },
   "pt": {
     "white-out": "Branquejar",
@@ -698,7 +710,8 @@
     "white_out": "Branquejar",
     "turnstile_status_prefix": "O filtro anti-robô indica:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ AVISO: Isto apagará permanentemente todo o quadro para todos.\n\nTem certeza de que deseja continuar?"
+    "clear_confirmation_message": "⚠️ AVISO: Isto apagará permanentemente todo o quadro para todos.\n\nTem certeza de que deseja continuar?",
+    "user_report_notice": "{reporter} denunciou {reported}"
   },
   "ru": {
     "board_name_placeholder": "Название доски",
@@ -752,7 +765,8 @@
     "white_out": "Корректор",
     "turnstile_status_prefix": "Антиробот-фильтр сообщает:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ ВНИМАНИЕ: это навсегда очистит всю доску для всех.\n\nВы уверены, что хотите продолжить?"
+    "clear_confirmation_message": "⚠️ ВНИМАНИЕ: это навсегда очистит всю доску для всех.\n\nВы уверены, что хотите продолжить?",
+    "user_report_notice": "{reporter} пожаловался на {reported}"
   },
   "sw": {
     "board_name_placeholder": "Jina la ubao mweupe ...",
@@ -806,7 +820,8 @@
     "white_out": "maji ya kusahihisha",
     "turnstile_status_prefix": "Kichujio cha kuzuia roboti kinasema:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ ONYO: Hii itafuta kabisa ubao mzima kwa kila mtu.\n\nUna uhakika unataka kuendelea?"
+    "clear_confirmation_message": "⚠️ ONYO: Hii itafuta kabisa ubao mzima kwa kila mtu.\n\nUna uhakika unataka kuendelea?",
+    "user_report_notice": "{reporter} alilalamika kuhusu {reported}"
   },
   "th": {
     "board_name_placeholder": "ชื่อไวท์บอร์ด ...",
@@ -860,7 +875,8 @@
     "white_out": "น้ำยาลบคำผิด",
     "turnstile_status_prefix": "ตัวกรองป้องกันหุ่นยนต์ระบุว่า:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ คำเตือน: การดำเนินการนี้จะล้างทั้งกระดานอย่างถาวรสำหรับทุกคน\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?"
+    "clear_confirmation_message": "⚠️ คำเตือน: การดำเนินการนี้จะล้างทั้งกระดานอย่างถาวรสำหรับทุกคน\n\nคุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?",
+    "user_report_notice": "{reporter} ร้องเรียนเกี่ยวกับ {reported}"
   },
   "uk": {
     "white-out": "Коректор",
@@ -914,7 +930,8 @@
     "white_out": "Коректор",
     "turnstile_status_prefix": "Антиробот-фільтр повідомляє:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ УВАГА: це назавжди очистить усю дошку для всіх.\n\nВи впевнені, що хочете продовжити?"
+    "clear_confirmation_message": "⚠️ УВАГА: це назавжди очистить усю дошку для всіх.\n\nВи впевнені, що хочете продовжити?",
+    "user_report_notice": "{reporter} поскаржився на {reported}"
   },
   "vi": {
     "white-out": "Bút xóa",
@@ -968,7 +985,8 @@
     "white_out": "Bút xóa",
     "turnstile_status_prefix": "Bộ lọc chống robot cho biết:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ CẢNH BÁO: Thao tác này sẽ xóa vĩnh viễn toàn bộ bảng cho mọi người.\n\nBạn có chắc chắn muốn tiếp tục không?"
+    "clear_confirmation_message": "⚠️ CẢNH BÁO: Thao tác này sẽ xóa vĩnh viễn toàn bộ bảng cho mọi người.\n\nBạn có chắc chắn muốn tiếp tục không?",
+    "user_report_notice": "{reporter} đã báo cáo {reported}"
   },
   "zh-CN": {
     "board_name_placeholder": "白板名称",
@@ -1022,7 +1040,8 @@
     "white_out": "修正液",
     "turnstile_status_prefix": "反机器人检查提示：",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ 警告：这将为所有人永久清空整个白板。\n\n确定要继续吗？"
+    "clear_confirmation_message": "⚠️ 警告：这将为所有人永久清空整个白板。\n\n确定要继续吗？",
+    "user_report_notice": "{reporter} 举报了 {reported}"
   },
   "zh-TW": {
     "board_name_placeholder": "白板名稱",
@@ -1076,7 +1095,8 @@
     "white_out": "修正液",
     "turnstile_status_prefix": "防機器人檢查提示：",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ 警告：這會為所有人永久清空整個白板。\n\n確定要繼續嗎？"
+    "clear_confirmation_message": "⚠️ 警告：這會為所有人永久清空整個白板。\n\n確定要繼續嗎？",
+    "user_report_notice": "{reporter} 檢舉了 {reported}"
   },
   "pl": {
     "board_name_placeholder": "Nazwa tablicy",
@@ -1130,6 +1150,7 @@
     "white_out": "Korektor",
     "turnstile_status_prefix": "Filtr antyrobotowy informuje:",
     "ban": "Ban",
-    "clear_confirmation_message": "⚠️ OSTRZEŻENIE: To trwale wyczyści całą tablicę dla wszystkich.\n\nCzy na pewno chcesz kontynuować?"
+    "clear_confirmation_message": "⚠️ OSTRZEŻENIE: To trwale wyczyści całą tablicę dla wszystkich.\n\nCzy na pewno chcesz kontynuować?",
+    "user_report_notice": "{reporter} zgłosił użytkownika {reported}"
   }
 }

--- a/server/socket/reports.mjs
+++ b/server/socket/reports.mjs
@@ -1,6 +1,7 @@
 import observability from "../observability/index.mjs";
+import { SocketEvents } from "../../client-data/js/socket_events.js";
 import { banBoardUser } from "./bans.mjs";
-import { getBoardUser } from "./presence.mjs";
+import { getBoardUser, getBoardUserMap } from "./presence.mjs";
 import { canBanOnBoard } from "./policy.mjs";
 
 const { logger, tracing } = observability;
@@ -68,6 +69,24 @@ function buildUserReportLog(boardName, { reported, reporter }, banned) {
     reported_name: reported.name,
     banned,
   };
+}
+
+/**
+ * @param {ReportUserContext} context
+ * @param {ReportUsers} users
+ * @returns {void}
+ */
+function notifyBoardModeratorsOfReport(context, users) {
+  const payload = {
+    reporterName: users.reporter.name,
+    reportedName: users.reported.name,
+  };
+  getBoardUserMap(context.boardName).forEach(function notifyUser(user) {
+    if (!user.canClear) return;
+    const socket = context.getActiveSocket(user.socketId);
+    if (!socket) return;
+    socket.emit(SocketEvents.USER_REPORTED, payload);
+  });
 }
 
 /**
@@ -208,6 +227,7 @@ function handleReportUserMessage(context) {
   const reportLog = buildUserReportLog(boardName, resolvedUsers, banned);
   lastUserReportLog = reportLog;
   logger.warn("user.reported", reportLog);
+  notifyBoardModeratorsOfReport(context, resolvedUsers);
 
   // Disconnect the reporter too to prevent abuse.
   disconnectReporter(context);

--- a/test-node/frontend_translations.test.js
+++ b/test-node/frontend_translations.test.js
@@ -58,6 +58,7 @@ test("frontend translation catalog covers rendered and runtime UI keys", () => {
     "text",
     "turnstile_status_prefix",
     "unknown_error_reload_page",
+    "user_report_notice",
     "users",
     "view_source",
     "white-out",

--- a/test-node/socket_users.test.js
+++ b/test-node/socket_users.test.js
@@ -2006,6 +2006,61 @@ test("report_user logs reporter and reported user details for active board membe
   );
 });
 
+test("report_user notifies connected moderators about reporter and reported users", async () => {
+  const moderatorSecret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  await createSocketScenario(
+    {
+      historyDirPrefix: "wbo-users-report-moderator-notice-",
+      config: {
+        BOARD_MODERATORS: new Map([
+          ["board-report-moderator-notice", new Set([moderatorSecret])],
+        ]),
+      },
+    },
+    async ({ connect, handler, sockets }) => {
+      const moderator = await connect({
+        id: "socket-report-notice-mod",
+        headers: withUserSecretCookie(moderatorSecret),
+        query: { board: "board-report-moderator-notice", tool: "hand" },
+      });
+      const reporter = await connect({
+        id: "socket-report-notice-reporter",
+        remoteAddress: "203.0.113.92",
+        query: { board: "board-report-moderator-notice", tool: "hand" },
+      });
+      const reported = await connect({
+        id: "socket-report-notice-reported",
+        remoteAddress: "203.0.113.93",
+        query: { board: "board-report-moderator-notice", tool: "hand" },
+      });
+
+      handler(
+        reporter,
+        "report_user",
+      )({
+        socketId: "socket-report-notice-reported",
+      });
+
+      const reportLog = getRequiredValue(sockets.__test.getLastUserReportLog());
+      const notice = moderator.emitted.find(
+        (event) => event.event === "user_reported",
+      );
+      assert.deepEqual(notice?.payload, {
+        reporterName: reportLog.reporter_name,
+        reportedName: reportLog.reported_name,
+      });
+      assert.equal(
+        reporter.emitted.some((event) => event.event === "user_reported"),
+        false,
+      );
+      assert.equal(
+        reported.emitted.some((event) => event.event === "user_reported"),
+        false,
+      );
+    },
+  );
+});
+
 test("report_user respects custom header ip sources for active board members", async () => {
   await createSocketScenario(
     {

--- a/types/app-runtime.d.ts
+++ b/types/app-runtime.d.ts
@@ -359,6 +359,11 @@ export type UserLeftPayload = {
   socketId: string;
 };
 
+export type UserReportedPayload = {
+  reporterName: string;
+  reportedName: string;
+};
+
 export type ClientSocketIncomingEventMap = {
   [SocketEvents.BOARDSTATE]: AppBoardState;
   [SocketEvents.BROADCAST]: IncomingBroadcast;
@@ -381,6 +386,7 @@ export type ClientSocketIncomingEventMap = {
     periodMs: number;
     retryAfterMs: number;
   };
+  [SocketEvents.USER_REPORTED]: UserReportedPayload;
   [SocketEvents.USER_JOINED]: ConnectedUser;
   [SocketEvents.USER_LEFT]: UserLeftPayload;
 };


### PR DESCRIPTION
### Motivation
- Moderators should see when one user reports another so they can respond without digging through server logs.
- The UI needs a localized, non-intrusive HUD message for connected moderators announcing reporter and reported display names.

### Description
- Add a new socket event `USER_REPORTED` and emit it from the server to connected moderators when a `report_user` is accepted. The server fans out only to users with moderator capabilities (`canClear`). (`server/socket/reports.mjs`, `client-data/js/socket_events.js`)
- Server-side `reports` logic now looks up board users and calls `socket.emit(SocketEvents.USER_REPORTED, { reporterName, reportedName })` for moderators only. (`server/socket/reports.mjs`)
- Client connection listens for `USER_REPORTED` and routes it to a new HUD helper which formats a localized message and displays it briefly. A small `formatStatusMessage` helper performs placeholder substitution. (`client-data/js/board_connection_module.js`, `client-data/js/board_status_module.js`)
- Add `user_report_notice` to the translation catalog and include the key in the frontend translation coverage test. (`server/http/translations.json`, `test-node/frontend_translations.test.js`)
- Add typed payload for the incoming event and a focused socket integration test that asserts moderators receive the `user_reported` event while the reporter and reported sockets do not. (`types/app-runtime.d.ts`, `test-node/socket_users.test.js`)

### Testing
- Ran `npm run format` and `npm run lint` (both succeeded).
- Ran focused unit/socket tests: `node --test --test-name-pattern "report_user notifies" test-node/socket_users.test.js` (passed) and `node --test test-node/frontend_translations.test.js` (passed).
- Ran `npm run typecheck` (passed).
- Ran the full Node test suite (`npm run test-node`) which passed locally; the full `npm test` run invoked Playwright browser tests which failed because Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ad8d2cf883318ba920f0325a326d)