### PR TITLE
Serve bundled static fallback assets

### DIFF
--- a/server/runtime/create_runtime.mjs
+++ b/server/runtime/create_runtime.mjs
@@ -55,14 +55,41 @@ function configuredTemplatePathWithBundledFallback(config, fileName) {
 }
 
 /**
- * Builds the cold, request-independent dependencies shared by HTTP routes.
- *
  * @param {ServerConfig} config
- * @returns {ServerRuntime}
+ * @returns {import("../../types/server-runtime.d.ts").StaticFileServer}
  */
-function createServerRuntime(config) {
-  const htmlHeadSnippet = readHtmlHeadSnippet(config);
-  const fileserver = serveStatic(config.WEBROOT, {
+function createStaticFileServer(config) {
+  const configuredFileserver = createSingleRootStaticFileServer(
+    config,
+    config.WEBROOT,
+  );
+  const configuredRoot = path.resolve(config.WEBROOT);
+  if (configuredRoot === BUNDLED_WEBROOT) return configuredFileserver;
+
+  const bundledFileserver = createSingleRootStaticFileServer(
+    config,
+    BUNDLED_WEBROOT,
+  );
+  return (request, response, next) => {
+    const originalUrl = request.url;
+    configuredFileserver(request, response, (error) => {
+      if (error !== undefined) {
+        next(error);
+        return;
+      }
+      request.url = originalUrl;
+      bundledFileserver(request, response, next);
+    });
+  };
+}
+
+/**
+ * @param {ServerConfig} config
+ * @param {string} root
+ * @returns {import("../../types/server-runtime.d.ts").StaticFileServer}
+ */
+function createSingleRootStaticFileServer(config, root) {
+  return serveStatic(root, {
     maxAge: 0,
     /** @param {HttpResponse} res */
     setHeaders: (res, /** @type {string} */ filePath) => {
@@ -71,6 +98,17 @@ function createServerRuntime(config) {
       if (cacheValue !== undefined) res.setHeader("Cache-Control", cacheValue);
     },
   });
+}
+
+/**
+ * Builds the cold, request-independent dependencies shared by HTTP routes.
+ *
+ * @param {ServerConfig} config
+ * @returns {ServerRuntime}
+ */
+function createServerRuntime(config) {
+  const htmlHeadSnippet = readHtmlHeadSnippet(config);
+  const fileserver = createStaticFileServer(config);
   const errorTemplate = new templating.Template(
     configuredTemplatePath(config, "error.html"),
     config,

--- a/test-node/server_routes.test.js
+++ b/test-node/server_routes.test.js
@@ -535,6 +535,39 @@ test("rules route uses base path and bundled template with custom webroot", asyn
       ),
     );
     assert.doesNotMatch(response.body, /\/custom\/base\/rules\?/);
+
+    const indexCss = await request(app, "/index.css");
+    assert.equal(indexCss.statusCode, 200);
+    assert.match(indexCss.headers["content-type"] || "", /text\/css/);
+    assert.match(indexCss.body, /--wbo-background/);
+
+    const rulesCss = await request(app, "/rules.css");
+    assert.equal(rulesCss.statusCode, 200);
+    assert.match(rulesCss.headers["content-type"] || "", /text\/css/);
+    assert.match(rulesCss.body, /rules-main/);
+
+    const favicon = await request(app, "/favicon.svg");
+    assert.equal(favicon.statusCode, 200);
+    assert.match(favicon.headers["content-type"] || "", /image\/svg\+xml/);
+    assert.match(favicon.body, /<svg/);
+  } finally {
+    await closeServer(app);
+  }
+});
+
+test("custom webroot static files take precedence over bundled fallback", async () => {
+  const dirs = await createServerDirs();
+  await fs.writeFile(
+    path.join(dirs.webroot, "index.css"),
+    "custom-css",
+    "utf8",
+  );
+  const app = await createTestServer(createServerConfig(dirs));
+  try {
+    const response = await request(app, "/index.css");
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, "custom-css");
   } finally {
     await closeServer(app);
   }


### PR DESCRIPTION
### Motivation
- When `WBO_WEBROOT` lacks `rules.html` the server fell back to the bundled template but the static file server remained rooted only at `config.WEBROOT`, causing linked CSS/icons to 404 for minimal custom webroots.

### Description
- Add a chained static file server via `createStaticFileServer` that serves from the configured `WEBROOT` first and falls back to the bundled `client-data` root so bundled templates can load their CSS and icons.
- Introduce `createSingleRootStaticFileServer` to encapsulate per-root `serve-static` creation and preserve existing response header/cache handling (`Content-Security-Policy` and `Cache-Control`).
- Use the chained fileserver in `createServerRuntime` so all static routes benefit from the fallback while keeping custom webroot assets precedence.
- Extend `test-node/server_routes.test.js` to assert the bundled `index.css`, `rules.css`, and `favicon.svg` are served for the bundled rules template and to verify custom webroot files override the bundled fallback.
- Files changed: `server/runtime/create_runtime.mjs`, `test-node/server_routes.test.js`.

### Testing
- Ran `node --test test-node/server_routes.test.js` and the suite passed locally (all tests green). 
- Ran lint with `npm run lint` and there were no lint errors. 
- Ran typecheck with `npm run typecheck` and the TypeScript check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3825ec7bd08331b52c9d35d99f0e43)