### PR TITLE
Eraser: use new 32×32 icon and set custom mouse cursor

### DIFF
--- a/client-data/tools/eraser/icon.svg
+++ b/client-data/tools/eraser/icon.svg
@@ -1,8 +1,14 @@
-<svg viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
-    <title>Eraser</title>
-    <g fill="none" stroke="#000" stroke-miterlimit="10">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21.38 50.39l-3.61-28.38M54.26 21.98l-3.75 28.4M40.58 22.09l8.17 10.02M30.42 22.13l17.15 20.64M22.35 24.25l21.87 26.17M23.9 37l12.03 13.63M25.32 49.4l1.36 1.35M23.23 31.23l8.58-9.13M24.61 41.88l18.24-19.75M26.89 50.63l22.49-23.92M36.57 50.63l11.55-11.95M44.22 50.75l2.12-1.79M14.91 12.03h42.05v5.95H14.91z"/>
-        <path d="M42.85 54.4h7.27"/>
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M50.12 54.4l-.7 5.57H22.43l-.68-5.57h28.37"/>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="32" height="32">
+  <title>Eraser</title>
+  <g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+    <path fill="#fff" d="M14 38.5 34.5 18c2.1-2.1 5.4-2.1 7.5 0l7.9 7.9c2.1 2.1 2.1 5.4 0 7.5L34.4 49H18.6L14 44.4c-1.6-1.6-1.6-4.3 0-5.9Z"/>
+    <path fill="#f3f4f6" d="m27.2 25.3 15.5 15.5-8.3 8.2H18.6L14 44.4c-1.6-1.6-1.6-4.3 0-5.9l13.2-13.2Z"/>
+    <path d="m27.2 25.3 15.5 15.5"/>
+    <path d="M18.6 49h27.8"/>
+    <path d="M12 52h19"/>
+    <path d="M36.4 17.1 50.8 31.5" opacity=".22"/>
+    <path d="M20.5 34.7 29 26.2" opacity=".35"/>
+    <path d="M37.7 45.6h4.7" opacity=".45"/>
+    <path d="M8.5 48.8h4.2M35.9 52h5.8M45 44.2h3.8"/>
+  </g>
 </svg>

--- a/client-data/tools/eraser/index.js
+++ b/client-data/tools/eraser/index.js
@@ -40,7 +40,6 @@ import { TOOL_CODE_BY_ID } from "../tool-order.js";
 export const toolId = "eraser";
 const toolCode = TOOL_CODE_BY_ID[toolId];
 export const shortcut = "e";
-export const mouseCursor = "crosshair";
 export const showMarker = true;
 export const liveMessageFields = /** @type {const} */ ({
   [MutationType.DELETE]: { id: "id" },
@@ -170,5 +169,6 @@ export function boot(ctx) {
     board: ctx.runtime.board,
     writes: ctx.runtime.writes,
     erasing: false,
+    mouseCursor: `url('${ctx.assetUrl("icon.svg")}') 8 24, crosshair`,
   };
 }


### PR DESCRIPTION
### Motivation

- Provide a modernized eraser asset and use it as the tool cursor so the UI shows a consistent icon when the eraser is active.
- Replace the previous hardcoded cursor export with a runtime cursor that references the bundled asset.

### Description

- Replace `client-data/tools/eraser/icon.svg` with a new 32×32 SVG that uses fills, updated viewBox, and simplified path structure.
- Remove the previous `export const mouseCursor = "crosshair";` and instead set `mouseCursor` on boot to ``url('${ctx.assetUrl("icon.svg")}') 8 24, crosshair`` so the eraser uses the new icon as a custom cursor.
- Preserve existing eraser behavior and metadata while wiring the runtime cursor to the tool boot context.

### Testing

- Ran the project's automated test suite with `npm test` and the tests completed successfully. 
- Ran the linter with `npm run lint` with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aaf0b2fc483319ace4947ab30e08d)