### PR TITLE
Persist selected board color

### DIFF
--- a/client-data/js/board_preferences.js
+++ b/client-data/js/board_preferences.js
@@ -2,6 +2,8 @@
 
 const DEFAULT_INITIAL_SIZE = 40;
 const DEFAULT_INITIAL_OPACITY = 1;
+const LOCAL_STORAGE_COLOR_KEY = "wbo.currentColor";
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
 export const DEFAULT_COLOR_PRESETS = [
   { color: "#001f3f", key: "1" },
@@ -18,10 +20,64 @@ export const DEFAULT_COLOR_PRESETS = [
 ];
 
 /**
+ * @param {unknown} color
+ * @returns {color is string}
+ */
+function isStoredColor(color) {
+  return typeof color === "string" && HEX_COLOR_RE.test(color);
+}
+
+/**
+ * @returns {Storage | null}
+ */
+function getLocalStorage() {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @returns {string | null}
+ */
+export function readStoredColorPreference() {
+  const storage = getLocalStorage();
+  if (!storage) return null;
+  try {
+    const color = storage.getItem(LOCAL_STORAGE_COLOR_KEY);
+    return isStoredColor(color) ? color : null;
+  } catch {
+    return null;
+  }
+}
+
+/** @param {string} color */
+export function saveStoredColorPreference(color) {
+  if (!isStoredColor(color)) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(LOCAL_STORAGE_COLOR_KEY, color);
+  } catch {
+    // Ignore browsers that make localStorage unavailable.
+  }
+}
+
+/**
  * @param {ColorPreset[]} colorPresets
  * @returns {AppInitialPreferences}
  */
 export function createInitialPreferences(colorPresets = DEFAULT_COLOR_PRESETS) {
+  const storedColor = readStoredColorPreference();
+  if (storedColor) {
+    return {
+      tool: "hand",
+      color: storedColor,
+      size: DEFAULT_INITIAL_SIZE,
+      opacity: DEFAULT_INITIAL_OPACITY,
+    };
+  }
   const colorIndex = (Math.random() * colorPresets.length) | 0;
   const initialPreset = colorPresets[colorIndex] || colorPresets[0];
   return {

--- a/client-data/js/board_runtime_core.js
+++ b/client-data/js/board_runtime_core.js
@@ -1,3 +1,4 @@
+import { saveStoredColorPreference } from "./board_preferences.js";
 import { DEFAULT_BOARD_SCALE } from "./board_viewport.js";
 import { clampCoord, clampOpacity, clampSize } from "./message_limits.js";
 
@@ -199,6 +200,7 @@ export class PreferenceModule {
   /** @param {string} color */
   setColor(color) {
     this.currentColor = color;
+    saveStoredColorPreference(color);
     if (this.colorChooser) {
       this.colorChooser.value = color;
     }

--- a/test-node/board_preferences.test.js
+++ b/test-node/board_preferences.test.js
@@ -1,0 +1,108 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+/** @param {Record<string, string>} [initialEntries] */
+function createLocalStorage(initialEntries = {}) {
+  const values = new Map(Object.entries(initialEntries));
+  return {
+    /** @param {string} key */
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    /**
+     * @param {string} key
+     * @param {string} value
+     */
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+  };
+}
+
+/**
+ * @template T
+ * @param {Record<string, unknown>} windowObject
+ * @param {() => T} callback
+ * @returns {T}
+ */
+function withWindow(windowObject, callback) {
+  const descriptor = Object.getOwnPropertyDescriptor(global, "window");
+  Object.defineProperty(global, "window", {
+    configurable: true,
+    enumerable: true,
+    value: windowObject,
+    writable: true,
+  });
+  try {
+    return callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(global, "window", descriptor);
+    } else {
+      delete (/** @type {any} */ (global).window);
+    }
+  }
+}
+
+/**
+ * @template T
+ * @param {number} value
+ * @param {() => T} callback
+ * @returns {T}
+ */
+function withMathRandom(value, callback) {
+  const original = Math.random;
+  Math.random = () => value;
+  try {
+    return callback();
+  } finally {
+    Math.random = original;
+  }
+}
+
+test("createInitialPreferences restores the stored color before choosing a random preset", async () => {
+  const { createInitialPreferences } = await import(
+    "../client-data/js/board_preferences.js"
+  );
+  const preferences = withWindow(
+    { localStorage: createLocalStorage({ "wbo.currentColor": "#123ABC" }) },
+    () =>
+      withMathRandom(0.99, () =>
+        createInitialPreferences([{ color: "#000000" }, { color: "#ffffff" }]),
+      ),
+  );
+
+  assert.equal(preferences.color, "#123ABC");
+});
+
+test("createInitialPreferences keeps random color choice when localStorage is empty", async () => {
+  const { createInitialPreferences } = await import(
+    "../client-data/js/board_preferences.js"
+  );
+  const preferences = withWindow({ localStorage: createLocalStorage() }, () =>
+    withMathRandom(0.75, () =>
+      createInitialPreferences([{ color: "#000000" }, { color: "#ffffff" }]),
+    ),
+  );
+
+  assert.equal(preferences.color, "#ffffff");
+});
+
+test("PreferenceModule persists color changes", async () => {
+  const storage = createLocalStorage();
+  const { PreferenceModule } = await import(
+    "../client-data/js/board_runtime_core.js"
+  );
+
+  withWindow({ localStorage: storage }, () => {
+    const preferences = new PreferenceModule([], {
+      tool: "hand",
+      color: "#000000",
+      size: 40,
+      opacity: 1,
+    });
+    preferences.setColor("#ff4136");
+  });
+
+  assert.equal(storage.getItem("wbo.currentColor"), "#ff4136");
+});


### PR DESCRIPTION
### Motivation

- Remember and restore the user's last-picked drawing color across page loads instead of always choosing a random preset, while preserving the existing random choice when no stored color exists.

### Description

- Added safe localStorage helpers and validation in `client-data/js/board_preferences.js`: `LOCAL_STORAGE_COLOR_KEY`, `HEX_COLOR_RE`, `getLocalStorage()`, `isStoredColor()`, `readStoredColorPreference()`, and `saveStoredColorPreference()`.
- Updated `createInitialPreferences()` in `client-data/js/board_preferences.js` to restore the stored color when available and fall back to the existing random preset only when storage is empty.
- Persisted color changes by importing and calling `saveStoredColorPreference()` from `PreferenceModule.setColor()` in `client-data/js/board_runtime_core.js`.
- Added Node tests in `test-node/board_preferences.test.js` to cover stored-color restoration, random fallback when storage is empty, and persistence when `setColor()` is called.

### Testing

- Ran `node --test test-node/board_preferences.test.js` and all tests passed.
- Ran `npm run lint` and the code passed lint checks.
- Ran `npm run typecheck` and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab00ca8f08331beb775aa4534f2b5)