### PR TITLE
feat: add select-all shortcut for selector

### DIFF
--- a/client-data/tools/hand/index.js
+++ b/client-data/tools/hand/index.js
@@ -59,7 +59,7 @@ import { TOOL_CODE_BY_ID } from "../tool-order.js";
 /** @typedef {HandPointSelection | HandScaleSelection | HandPanSelection | null} HandSelection */
 /** @typedef {{x: number, y: number} | {a: number, d: number, e: number, f: number} | undefined} SelectionRectTransform */
 /** @typedef {(x: number, y: number, force: boolean) => void} HandTransformHandler */
-/** @typedef {(e: { key: string, target: EventTarget | null }) => void} HandShortcutHandler */
+/** @typedef {(e: { key: string, target: EventTarget | null, ctrlKey?: boolean, metaKey?: boolean, altKey?: boolean, preventDefault?: () => void }) => void} HandShortcutHandler */
 /** @typedef {{ name: string, icon: string, active: boolean, switch?: () => void }} HandSecondary */
 /** @typedef {import("../../js/intersect.js").Point2D} Point2D */
 /** @typedef {import("../../js/intersect.js").TransformedBBox} TransformedBBox */
@@ -278,6 +278,7 @@ function createInitialState(Tools, assetUrl) {
     selectionButtons: /** @type {SelectionButton[]} */ ([]),
     boundDeleteShortcut: /** @type {HandShortcutHandler} */ (() => {}),
     boundDuplicateShortcut: /** @type {HandShortcutHandler} */ (() => {}),
+    boundSelectAllShortcut: /** @type {HandShortcutHandler} */ (() => {}),
     secondary: /** @type {HandSecondary | null} */ (null),
   };
 }
@@ -389,6 +390,7 @@ function createState(Tools, assetUrl) {
   });
   state.boundDeleteShortcut = (e) => deleteShortcut(state, e);
   state.boundDuplicateShortcut = (e) => duplicateShortcut(state, e);
+  state.boundSelectAllShortcut = (e) => selectAllShortcut(state, e);
   state.secondary = Tools.permissions.canEdit
     ? {
         name: "Selector",
@@ -931,6 +933,64 @@ function finishSelection(state, selected, runId) {
 
 /**
  * @param {HandState} state
+ * @param {(SVGGraphicsElement & { id: string })[]} elements
+ * @returns {void}
+ */
+function updateSelectionRectFromElements(state, elements) {
+  let bounds = null;
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i];
+    if (!element) continue;
+    const rect = transformedBBoxToBoardRect(element.transformedBBox());
+    bounds = bounds
+      ? {
+          x: Math.min(bounds.x, rect.x),
+          y: Math.min(bounds.y, rect.y),
+          width:
+            Math.max(bounds.x + bounds.width, rect.x + rect.width) -
+            Math.min(bounds.x, rect.x),
+          height:
+            Math.max(bounds.y + bounds.height, rect.y + rect.height) -
+            Math.min(bounds.y, rect.y),
+        }
+      : rect;
+  }
+  if (!bounds) {
+    hideSelectionUI(state);
+    return;
+  }
+  state.selectionRect.x.baseVal.value = bounds.x;
+  state.selectionRect.y.baseVal.value = bounds.y;
+  state.selectionRect.width.baseVal.value = bounds.width;
+  state.selectionRect.height.baseVal.value = bounds.height;
+  state.selectionRect.style.display = "";
+  const tmatrix = getTransformMatrix(state, state.selectionRect);
+  tmatrix.a = 1;
+  tmatrix.b = 0;
+  tmatrix.c = 0;
+  tmatrix.d = 1;
+  tmatrix.e = 0;
+  tmatrix.f = 0;
+  syncSelectionChrome(state);
+}
+
+/** @param {HandState} state */
+function selectAllElements(state) {
+  state.selected = null;
+  state.selectorState = state.selectorStates.pointing;
+  state.currentTransform = null;
+  state.transformElements = [];
+  state.selectedEls = getSelectableElements(state);
+  if (state.selectedEls.length === 0) {
+    hideSelectionUI(state);
+    return;
+  }
+  updateSelectionRectFromElements(state, state.selectedEls);
+  showSelectionButtons(state);
+}
+
+/**
+ * @param {HandState} state
  * @param {number} runId
  * @returns {Promise<void> | void}
  */
@@ -1338,6 +1398,7 @@ function resetHandUiState(state) {
   hideSelectionUI(state);
   window.removeEventListener("keydown", state.boundDeleteShortcut);
   window.removeEventListener("keydown", state.boundDuplicateShortcut);
+  window.removeEventListener("keydown", state.boundSelectAllShortcut);
 }
 
 /**
@@ -1405,12 +1466,28 @@ function duplicateShortcut(state, e) {
   }
 }
 
+/** @param {HandState} state @param {{ key: string, target: EventTarget | null, ctrlKey?: boolean, metaKey?: boolean, altKey?: boolean, preventDefault?: () => void }} e */
+function selectAllShortcut(state, e) {
+  if (
+    e.key.toLowerCase() !== "a" ||
+    !(e.ctrlKey || e.metaKey) ||
+    e.altKey ||
+    (isMatchableTarget(e.target) &&
+      e.target.matches("input[type=text], textarea"))
+  ) {
+    return;
+  }
+  e.preventDefault?.();
+  selectAllElements(state);
+}
+
 /** @param {HandState} state */
 function switchTool(state) {
   resetHandUiState(state);
   if (isSelectorActive(state)) {
     window.addEventListener("keydown", state.boundDeleteShortcut);
     window.addEventListener("keydown", state.boundDuplicateShortcut);
+    window.addEventListener("keydown", state.boundSelectAllShortcut);
   }
 }
 

--- a/test-node/client_tool_replay.test.js
+++ b/test-node/client_tool_replay.test.js
@@ -2479,6 +2479,62 @@ test("Hand selector keeps the original element selected after duplicate", async 
   });
 });
 
+test("Hand selector supports Ctrl+A to select all before deleting", async () => {
+  const harness = createHarness();
+  const handTool = await harness.loadTool("hand");
+  await harness.loadTool("eraser");
+
+  const firstRect = globalAny.Tools.dom.createSVGElement("rect");
+  firstRect.id = "r-1";
+  firstRect.x.baseVal.value = 100;
+  firstRect.y.baseVal.value = 100;
+  firstRect.width.baseVal.value = 60;
+  firstRect.height.baseVal.value = 40;
+  globalAny.Tools.drawingArea.appendChild(firstRect);
+
+  const secondRect = globalAny.Tools.dom.createSVGElement("rect");
+  secondRect.id = "r-2";
+  secondRect.x.baseVal.value = 240;
+  secondRect.y.baseVal.value = 160;
+  secondRect.width.baseVal.value = 80;
+  secondRect.height.baseVal.value = 50;
+  globalAny.Tools.drawingArea.appendChild(secondRect);
+
+  handTool.secondary.active = true;
+  handTool.secondary.switch();
+
+  let preventDefaultCount = 0;
+  harness.time.dispatchWindowEvent("keydown", {
+    key: "a",
+    ctrlKey: true,
+    target: null,
+    preventDefault() {
+      preventDefaultCount += 1;
+    },
+  });
+
+  harness.time.dispatchWindowEvent("keydown", {
+    key: "Delete",
+    target: null,
+  });
+
+  assert.equal(preventDefaultCount, 1);
+  assert.equal(globalAny.Tools.sentMessages.length, 1);
+  assert.deepEqual(globalAny.Tools.sentMessages[0].data, {
+    tool: TOOL_CODE_BY_ID.hand,
+    _children: [
+      {
+        type: MessageToolMetadata.MutationType.DELETE,
+        id: "r-1",
+      },
+      {
+        type: MessageToolMetadata.MutationType.DELETE,
+        id: "r-2",
+      },
+    ],
+  });
+});
+
 test("Hand selector ignores stale async selection after transform starts", async () => {
   const harness = createHarness();
   const handTool = await harness.loadTool("hand");


### PR DESCRIPTION
## Summary
- add `Ctrl/Cmd + A` support for the hand tool selector mode
- reuse the existing selection chrome so full-board selections can be deleted immediately
- add a regression test covering select-all followed by delete

## Why
`lovasoa/whitebophir#324` asks for a way to select everything on the board instead of relying on the floating selection controls staying visible.

This keeps the change narrow: it only applies while the selector sub-tool is active, and it leaves the existing box-selection path untouched.

## Testing
- `node --test test-node/client_tool_replay.test.js`
- `npx @biomejs/biome check client-data/tools/hand/index.js test-node/client_tool_replay.test.js`